### PR TITLE
Display an error message when ffmpeg.exe is missing.

### DIFF
--- a/YoutubePlaylistDownloader/DownloadPage.xaml.cs
+++ b/YoutubePlaylistDownloader/DownloadPage.xaml.cs
@@ -185,7 +185,7 @@ namespace YoutubePlaylistDownloader
             StillDownloading = true;
 
             ImageUrl = $"https://img.youtube.com/vi/{Videos?.FirstOrDefault()?.Id}/0.jpg";
-            Title = playlist.BasePlaylist?.Title;
+            Title = playlist?.BasePlaylist?.Title;
             CurrentTitle = (string)FindResource("Loading");
             TotalDownloaded = $"(0/{Maximum})";
             CurrentProgressPrecent = 0;
@@ -374,7 +374,7 @@ namespace YoutubePlaylistDownloader
                                 EnableRaisingEvents = true,
                                 StartInfo = new ProcessStartInfo()
                                 {
-                                    FileName = $"{GlobalConsts.CurrentDir}\\ffmpeg.exe",
+                                    FileName = GlobalConsts.FFmpegFilePath,
                                     Arguments = $"-i \"{fileLoc}\" -y {Bitrate} \"{outputFileLoc}\"",
                                     CreateNoWindow = true,
                                     UseShellExecute = false
@@ -684,7 +684,7 @@ namespace YoutubePlaylistDownloader
                         EnableRaisingEvents = true,
                         StartInfo = new ProcessStartInfo()
                         {
-                            FileName = $"{GlobalConsts.CurrentDir}\\ffmpeg.exe",
+                            FileName = GlobalConsts.FFmpegFilePath,
                             Arguments = ffmpegArguments,
                             CreateNoWindow = true,
                             UseShellExecute = false,

--- a/YoutubePlaylistDownloader/GlobalConsts.cs
+++ b/YoutubePlaylistDownloader/GlobalConsts.cs
@@ -32,6 +32,7 @@ namespace YoutubePlaylistDownloader
         public static readonly string TempFolderPath;
         public static string SaveDirectory;
         public static readonly string CurrentDir;
+        public static readonly string FFmpegFilePath;
         private static readonly string ConfigFilePath;
         private static readonly string ErrorFilePath;
         public const double VERSION = 1.817;
@@ -97,6 +98,7 @@ namespace YoutubePlaylistDownloader
         {
             Downloads = new ObservableCollection<QueuedDownload>();
             CurrentDir = new FileInfo(Assembly.GetEntryAssembly().Location).Directory.ToString();
+            FFmpegFilePath = $"{CurrentDir}\\ffmpeg.exe";
             string appDataPath = string.Concat(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "\\Youtube Playlist Downloader\\");
             ConfigFilePath = string.Concat(appDataPath, "Settings.json");
             ErrorFilePath = string.Concat(appDataPath, "Errors.txt");

--- a/YoutubePlaylistDownloader/Languages/Deutsch.xaml
+++ b/YoutubePlaylistDownloader/Languages/Deutsch.xaml
@@ -150,4 +150,5 @@ Beispiel: Hat Ihre CPU hat vier Kerne, so stellen Sie drei gleichzeitge Konverti
     <s:String x:Key="DownloadFilter">Only download videos</s:String>
     <s:String x:Key="Longer">longer</s:String>
     <s:String x:Key="Shorter">shorter</s:String>
+    <s:String x:Key="FileDoesNotExist">{0} does not exist.</s:String>
 </ResourceDictionary> 

--- a/YoutubePlaylistDownloader/Languages/English.xaml
+++ b/YoutubePlaylistDownloader/Languages/English.xaml
@@ -152,4 +152,5 @@ the file convertion to 2, etc..</s:String>
     <s:String x:Key="DownloadFilter">Only download videos</s:String>
     <s:String x:Key="Longer">longer</s:String>
     <s:String x:Key="Shorter">shorter</s:String>
+    <s:String x:Key="FileDoesNotExist">{0} does not exist.</s:String>
 </ResourceDictionary> 

--- a/YoutubePlaylistDownloader/Languages/Español.xaml
+++ b/YoutubePlaylistDownloader/Languages/Español.xaml
@@ -149,4 +149,5 @@ Se recomienda utilizar 1 núcleo menos de los que tienes disponibles. Si tu comp
     <s:String x:Key="DownloadFilter">Only download videos</s:String>
     <s:String x:Key="Longer">longer</s:String>
     <s:String x:Key="Shorter">shorter</s:String>
+    <s:String x:Key="FileDoesNotExist">{0} does not exist.</s:String>
 </ResourceDictionary> 

--- a/YoutubePlaylistDownloader/Languages/Italiano.xaml
+++ b/YoutubePlaylistDownloader/Languages/Italiano.xaml
@@ -150,4 +150,5 @@ su quattro; in Gestione Attività si vedrà che il programma usa poco più del 7
     <s:String x:Key="DownloadFilter">Only download videos</s:String>
     <s:String x:Key="Longer">longer</s:String>
     <s:String x:Key="Shorter">shorter</s:String>
+    <s:String x:Key="FileDoesNotExist">{0} does not exist.</s:String>
 </ResourceDictionary>

--- a/YoutubePlaylistDownloader/Languages/Português (BR).xaml
+++ b/YoutubePlaylistDownloader/Languages/Português (BR).xaml
@@ -153,4 +153,5 @@ the file convertion to 2, etc..</s:String>
     <s:String x:Key="DownloadFilter">Only download videos</s:String>
     <s:String x:Key="Longer">longer</s:String>
     <s:String x:Key="Shorter">shorter</s:String>
+    <s:String x:Key="FileDoesNotExist">{0} does not exist.</s:String>
 </ResourceDictionary>

--- a/YoutubePlaylistDownloader/Languages/Türkçe.xaml
+++ b/YoutubePlaylistDownloader/Languages/Türkçe.xaml
@@ -153,4 +153,5 @@ dosya dönüştürmeyi 3 ile sınırlandırarak 3 çekirdek kullanın, 3 çekird
     <s:String x:Key="DownloadFilter">Only download videos</s:String>
     <s:String x:Key="Longer">longer</s:String>
     <s:String x:Key="Shorter">shorter</s:String>
+    <s:String x:Key="FileDoesNotExist">{0} does not exist.</s:String>
 </ResourceDictionary> 

--- a/YoutubePlaylistDownloader/Languages/עברית.xaml
+++ b/YoutubePlaylistDownloader/Languages/עברית.xaml
@@ -152,4 +152,5 @@ the file convertion to 2, etc..</s:String>
     <s:String x:Key="DownloadFilter">הורד רק סרטונים</s:String>
     <s:String x:Key="Longer">ארוכים</s:String>
     <s:String x:Key="Shorter">קצרים</s:String>
+    <s:String x:Key="FileDoesNotExist">{0} does not exist.</s:String>
 </ResourceDictionary>

--- a/YoutubePlaylistDownloader/Languages/中文.xaml
+++ b/YoutubePlaylistDownloader/Languages/中文.xaml
@@ -136,4 +136,5 @@ the file convertion to 2, etc..</s:String>
     <s:String x:Key="DownloadFilter">Only download videos</s:String>
     <s:String x:Key="Longer">longer</s:String>
     <s:String x:Key="Shorter">shorter</s:String>
+    <s:String x:Key="FileDoesNotExist">{0} does not exist.</s:String>
 </ResourceDictionary>

--- a/YoutubePlaylistDownloader/MainPage.xaml.cs
+++ b/YoutubePlaylistDownloader/MainPage.xaml.cs
@@ -12,6 +12,7 @@ using YoutubeExplode.Videos.Streams;
 using YoutubeExplode.Channels;
 using YoutubePlaylistDownloader.Utilities;
 using YoutubePlaylistDownloader.Objects;
+using System.IO;
 
 namespace YoutubePlaylistDownloader
 {
@@ -140,6 +141,12 @@ namespace YoutubePlaylistDownloader
         {
             if (list != null || VideoList.Any())
             {
+                if (!CanDownload())
+                {
+                    GlobalConsts.ShowMessage((string)FindResource("Error"), $"{string.Format((string)FindResource("FileDoesNotExist"), GlobalConsts.FFmpegFilePath)}").ConfigureAwait(false);
+                    return;
+                }
+
                 GlobalConsts.LoadPage(new DownloadPage(list, GlobalConsts.DownloadSettings.Clone(), videos: VideoList));
                 VideoList= new List<Video>();
                 PlaylistLinkTextBox.Text = string.Empty;
@@ -183,6 +190,12 @@ namespace YoutubePlaylistDownloader
         {
             if (list != null || VideoList.Any())
             {
+                if (!CanDownload())
+                {
+                    GlobalConsts.ShowMessage((string)FindResource("Error"), $"{string.Format((string)FindResource("FileDoesNotExist"), GlobalConsts.FFmpegFilePath)}").ConfigureAwait(false);
+                    return;
+                }
+
                 new DownloadPage(list, GlobalConsts.DownloadSettings.Clone(), silent: true, videos: VideoList);
                 VideoList= new List<Video>();
                 PlaylistLinkTextBox.Text = string.Empty;
@@ -197,6 +210,13 @@ namespace YoutubePlaylistDownloader
         private void BulkDownloadButton_Click(object sender, RoutedEventArgs e)
         {
             var links = BulkLinksTextBox.Text.Split(new string[] { "\r\n" }, StringSplitOptions.RemoveEmptyEntries);
+
+            if (!CanDownload())
+            {
+                GlobalConsts.ShowMessage((string)FindResource("Error"), $"{string.Format((string)FindResource("FileDoesNotExist"), GlobalConsts.FFmpegFilePath)}").ConfigureAwait(false);
+                return;
+            }
+
             _ = DownloadPage.SequenceDownload(links, GlobalConsts.DownloadSettings.Clone(), silent: true);
             BulkLinksTextBox.Text = string.Empty;
             MetroAnimatedTabControl.SelectedItem = QueueMetroTabItem;
@@ -205,6 +225,11 @@ namespace YoutubePlaylistDownloader
         private void TextBox_TextChanged_1(object sender, TextChangedEventArgs e)
         {
             BulkDownloadButton.IsEnabled = !string.IsNullOrWhiteSpace(BulkLinksTextBox.Text);
+        }
+
+        private bool CanDownload()
+        {
+            return GlobalConsts.DownloadSettings.AudioOnly || File.Exists(GlobalConsts.FFmpegFilePath);
         }
     }
 }


### PR DESCRIPTION
When _ffmpeg.exe_ is missing the download starts, audio/video streams are downloaded to the temporary directory, but then nothing happens.

Would be really helpful to see an error message instead. I added the check before the download page is loaded (_fail-fast_) and only when _ffmpeg.exe_ is required (video/audio muxing or audio conversion).

![image](https://user-images.githubusercontent.com/12585988/91624506-66b36880-e9a9-11ea-954d-30219aa8de22.png)

Please let me know if I missed anything.
