### PR TITLE
Fix Check for updates

### DIFF
--- a/YoutubePlaylistDownloader/About.xaml.cs
+++ b/YoutubePlaylistDownloader/About.xaml.cs
@@ -28,7 +28,7 @@ namespace YoutubePlaylistDownloader
             {
                 using (var wc = new WebClient())
                 {
-                    var latestVersion = double.Parse(await wc.DownloadStringTaskAsync("https://raw.githubusercontent.com/shaked6540/YoutubePlaylistDownloader/master/YoutubePlaylistDownloader/latestVersion.txt"));
+                    var latestVersion = Version.Parse(await wc.DownloadStringTaskAsync("https://raw.githubusercontent.com/shaked6540/YoutubePlaylistDownloader/master/YoutubePlaylistDownloader/latestVersion.txt"));
 
                     if (latestVersion > GlobalConsts.VERSION)
                     {

--- a/YoutubePlaylistDownloader/DownloadUpdate.xaml.cs
+++ b/YoutubePlaylistDownloader/DownloadUpdate.xaml.cs
@@ -15,7 +15,7 @@ namespace YoutubePlaylistDownloader
     /// </summary>
     public partial class DownloadUpdate : UserControl, IDownload
     {
-        private double latestVersion;
+        private Version latestVersion;
         private bool downloadFinished;
         private string updateSetupLocation;
 
@@ -94,7 +94,7 @@ namespace YoutubePlaylistDownloader
             }
         }
 
-        public DownloadUpdate(double latestVersion, string changelog, bool updateLater = false)
+        public DownloadUpdate(Version latestVersion, string changelog, bool updateLater = false)
         {
             InitializeComponent();
             if (!updateLater)

--- a/YoutubePlaylistDownloader/GlobalConsts.cs
+++ b/YoutubePlaylistDownloader/GlobalConsts.cs
@@ -35,7 +35,7 @@ namespace YoutubePlaylistDownloader
         public static readonly string FFmpegFilePath;
         private static readonly string ConfigFilePath;
         private static readonly string ErrorFilePath;
-        public const double VERSION = 1.817;
+        public static readonly Version VERSION = new Version(1, 817);
         public static bool UpdateOnExit;
         public static string UpdateSetupLocation;
         public static bool OptionExpanderIsExpanded;

--- a/YoutubePlaylistDownloader/Skeleton.xaml.cs
+++ b/YoutubePlaylistDownloader/Skeleton.xaml.cs
@@ -35,7 +35,8 @@ namespace YoutubePlaylistDownloader
             {
                 using (var wc = new WebClient() { CachePolicy = new System.Net.Cache.RequestCachePolicy(System.Net.Cache.RequestCacheLevel.NoCacheNoStore) })
                 {
-                    var latestVersion = double.Parse(await wc.DownloadStringTaskAsync("https://raw.githubusercontent.com/shaked6540/YoutubePlaylistDownloader/master/YoutubePlaylistDownloader/latestVersion.txt"));
+                    var latestVersion = Version.Parse(await wc.DownloadStringTaskAsync("https://raw.githubusercontent.com/shaked6540/YoutubePlaylistDownloader/master/YoutubePlaylistDownloader/latestVersion.txt"));
+                    
                     if (latestVersion > GlobalConsts.VERSION)
                     {
                         var changelog = await wc.DownloadStringTaskAsync("https://raw.githubusercontent.com/shaked6540/YoutubePlaylistDownloader/master/YoutubePlaylistDownloader/changelog.txt");


### PR DESCRIPTION
 - use the built-in Version class to compare versions otherwise on systems with different number formatting settings (i.e. non-English) this may yield incorrect results.

My system uses a comma (,) for decimal symbol and a period (.) for digit grouping. So when the application parses the latest version from GitHub as a double, which is at this moment "1.817" it will result in the number 1817 (one thousand eight hundred and seventeen) which is greater than the application version which is 1.817 (one point eight one seven). So the solution is to use the built-in Version class for internal representation. This will also fix the display of the version number (with a period and not with a comma).

Before the fix.
![image](https://user-images.githubusercontent.com/12585988/91645061-9cf4f480-ea4a-11ea-8002-2d6f6c04fb71.png)

After the fix.
![image](https://user-images.githubusercontent.com/12585988/91645067-a2ead580-ea4a-11ea-8bb8-be41c9eb487d.png)
