### PR TITLE
Updated YoutubeExplode to the latest version.

### DIFF
--- a/YoutubePlaylistDownloader/YoutubePlaylistDownloader.csproj
+++ b/YoutubePlaylistDownloader/YoutubePlaylistDownloader.csproj
@@ -164,8 +164,8 @@
     <Reference Include="WindowsBase" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
-    <Reference Include="YoutubeExplode, Version=5.1.9.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\YoutubeExplode.5.1.9\lib\net461\YoutubeExplode.dll</HintPath>
+    <Reference Include="YoutubeExplode, Version=6.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\YoutubeExplode.6.0.0-alpha\lib\net461\YoutubeExplode.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/YoutubePlaylistDownloader/packages.config
+++ b/YoutubePlaylistDownloader/packages.config
@@ -27,5 +27,5 @@
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net462" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net462" />
   <package id="TagLibSharp" version="2.2.0" targetFramework="net462" />
-  <package id="YoutubeExplode" version="5.1.9" targetFramework="net462" />
+  <package id="YoutubeExplode" version="6.0.0-alpha" targetFramework="net462" />
 </packages>


### PR DESCRIPTION
The solution cannot be built with the latest code changes. It seems that the update of the YoutubeExplode library was not included in the commits.