### PR TITLE
Update the solution file to open with Visual Studio 2019.

### DIFF
--- a/YoutubePlaylistDownloader.sln
+++ b/YoutubePlaylistDownloader.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26730.12
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.33027.164
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "YoutubePlaylistDownloader", "YoutubePlaylistDownloader\YoutubePlaylistDownloader.csproj", "{57ADF475-AC13-4912-A26B-100C6535A74D}"
 EndProject


### PR DESCRIPTION
Hi.

I have multiple versions of Visual Studio Installed (2015, 2017, 2019, and 2022), and I keep forgetting with which I should open this project. I've updated the solution file version to (open with) Visual Studio 2019 (v16.x) when you double-click since this is the least supported version with which the project can be built due to the use of newer C# language features.

Below you can see that the icon changes dynamically based on the `VisualStudioVersion` value.

_Before_
![image](https://user-images.githubusercontent.com/12585988/206933605-5f78cfba-0db4-40b3-bc87-106878e0204f.png)

_After_
![image](https://user-images.githubusercontent.com/12585988/206933608-f853075a-f25f-433e-a405-e9433d776a2f.png)

