### PR TITLE
Fixed total downloads progress bar text by replacing (incorrect) backslash with 'of'.

### DIFF
--- a/YoutubePlaylistDownloader/DownloadPage.xaml.cs
+++ b/YoutubePlaylistDownloader/DownloadPage.xaml.cs
@@ -539,7 +539,7 @@ namespace YoutubePlaylistDownloader
                         HeadlineTextBlock.Text = (string)FindResource("AllDone");
                         CurrentDownloadProgressBar.IsIndeterminate = true;
                         TotalDownloadedGrid.Visibility = Visibility.Collapsed;
-                        TotalDownloadsProgressBarTextBlock.Text = $"({DownloadedCount}\\{Maximum})";
+                        TotalDownloadsProgressBarTextBlock.Text = $"({DownloadedCount} {FindResource("Of")} {Maximum})";
                         DownloadedVideosProgressBar.Value = Maximum;
                         ConvertingTextBlock.Visibility = Visibility.Visible;
                         ConvertingTextBlock.Text = status;
@@ -566,7 +566,7 @@ namespace YoutubePlaylistDownloader
                     Title = allDone;
                     HeadlineTextBlock.Text = allDone;
                     TotalDownloadedGrid.Visibility = Visibility.Collapsed;
-                    TotalDownloadsProgressBarTextBlock.Text = $"({DownloadedCount}\\{Maximum})";
+                    TotalDownloadsProgressBarTextBlock.Text = $"({DownloadedCount} {FindResource("Of")} {Maximum})";
                     DownloadedVideosProgressBar.Value = Maximum;
                     CurrentDownloadProgressBarTextBlock.Visibility = Visibility.Collapsed;
                 });
@@ -844,7 +844,7 @@ namespace YoutubePlaylistDownloader
                     HeadlineTextBlock.Text = (string)FindResource("AllDone");
                     CurrentDownloadProgressBar.IsIndeterminate = true;
                     TotalDownloadedGrid.Visibility = Visibility.Collapsed;
-                    TotalDownloadsProgressBarTextBlock.Text = $"({DownloadedCount}\\{Maximum})";
+                    TotalDownloadsProgressBarTextBlock.Text = $"({DownloadedCount} {FindResource("Of")} {Maximum})";
                     DownloadedVideosProgressBar.Value = Maximum;
                     ConvertingTextBlock.Visibility = Visibility.Visible;
                     ConvertingTextBlock.Text = status;
@@ -875,7 +875,7 @@ namespace YoutubePlaylistDownloader
                 Title = allDone;
                 HeadlineTextBlock.Text = allDone;
                 TotalDownloadedGrid.Visibility = Visibility.Collapsed;
-                TotalDownloadsProgressBarTextBlock.Text = $"({DownloadedCount}\\{Maximum})";
+                TotalDownloadsProgressBarTextBlock.Text = $"({DownloadedCount} {FindResource("Of")} {Maximum})";
                 DownloadedVideosProgressBar.Value = Maximum;
                 CurrentDownloadProgressBarTextBlock.Visibility = Visibility.Collapsed;
             });
@@ -898,7 +898,7 @@ namespace YoutubePlaylistDownloader
             CurrentDownloadProgressBar.Value = precent;
             HeadlineTextBlock.Text = (string)FindResource("CurrentlyDownlading") + video.Title;
             CurrentDownloadProgressBarTextBlock.Text = $"{precent}%";
-            TotalDownloadsProgressBarTextBlock.Text = $"{DownloadedCount}\\{Maximum}";
+            TotalDownloadsProgressBarTextBlock.Text = $"{DownloadedCount} {FindResource("Of")} {Maximum}";
             DownloadedVideosProgressBar.Value = DownloadedCount;
         }
 

--- a/YoutubePlaylistDownloader/Languages/Deutsch.xaml
+++ b/YoutubePlaylistDownloader/Languages/Deutsch.xaml
@@ -154,5 +154,5 @@ Beispiel: Hat Ihre CPU hat vier Kerne, so stellen Sie drei gleichzeitge Konverti
     <s:String x:Key="Shorter">shorter</s:String>
     <s:String x:Key="FileDoesNotExist">{0} does not exist.</s:String>
     <s:String x:Key="Retry">Retry</s:String>
-
+    <s:String x:Key="Of">of</s:String>
 </ResourceDictionary> 

--- a/YoutubePlaylistDownloader/Languages/English.xaml
+++ b/YoutubePlaylistDownloader/Languages/English.xaml
@@ -158,4 +158,5 @@ the file conversion to 2, etc.</s:String>
     <s:String x:Key="Shorter">shorter</s:String>
     <s:String x:Key="FileDoesNotExist">{0} does not exist.</s:String>
     <s:String x:Key="Retry">Retry</s:String>
+    <s:String x:Key="Of">of</s:String>
 </ResourceDictionary> 

--- a/YoutubePlaylistDownloader/Languages/Español.xaml
+++ b/YoutubePlaylistDownloader/Languages/Español.xaml
@@ -153,4 +153,5 @@ Se recomienda utilizar 1 núcleo menos de los que tienes disponibles. Si tu comp
     <s:String x:Key="Shorter">shorter</s:String>
     <s:String x:Key="FileDoesNotExist">{0} does not exist.</s:String>
     <s:String x:Key="Retry">Retry</s:String>
+    <s:String x:Key="Of">of</s:String>
 </ResourceDictionary> 

--- a/YoutubePlaylistDownloader/Languages/Français.xaml
+++ b/YoutubePlaylistDownloader/Languages/Français.xaml
@@ -156,4 +156,5 @@ la conversion du fichier à 2, etc.</s:String>
     <s:String x:Key="Shorter">plus courtes</s:String>
     <s:String x:Key="FileDoesNotExist">{0} n'existe pas.</s:String>
     <s:String x:Key="Retry">Retry</s:String>
+    <s:String x:Key="Of">of</s:String>
 </ResourceDictionary> 

--- a/YoutubePlaylistDownloader/Languages/Italiano.xaml
+++ b/YoutubePlaylistDownloader/Languages/Italiano.xaml
@@ -154,4 +154,5 @@ su quattro; in Gestione Attività si vedrà che il programma usa poco più del 7
     <s:String x:Key="Shorter">piú corti</s:String>
     <s:String x:Key="FileDoesNotExist">{0} non esiste.</s:String>
     <s:String x:Key="Retry">Retry</s:String>
+    <s:String x:Key="Of">of</s:String>
 </ResourceDictionary>

--- a/YoutubePlaylistDownloader/Languages/Português (BR).xaml
+++ b/YoutubePlaylistDownloader/Languages/Português (BR).xaml
@@ -157,4 +157,5 @@ the file convertion to 2, etc..</s:String>
     <s:String x:Key="Shorter">shorter</s:String>
     <s:String x:Key="FileDoesNotExist">{0} does not exist.</s:String>
     <s:String x:Key="Retry">Retry</s:String>
+    <s:String x:Key="Of">of</s:String>
 </ResourceDictionary>

--- a/YoutubePlaylistDownloader/Languages/Türkçe.xaml
+++ b/YoutubePlaylistDownloader/Languages/Türkçe.xaml
@@ -157,4 +157,5 @@ dosya dönüştürmeyi 3 ile sınırlandırarak 3 çekirdek kullanın, 3 çekird
     <s:String x:Key="Shorter">shorter</s:String>
     <s:String x:Key="FileDoesNotExist">{0} does not exist.</s:String>
     <s:String x:Key="Retry">Retry</s:String>
+    <s:String x:Key="Of">of</s:String>
 </ResourceDictionary> 

--- a/YoutubePlaylistDownloader/Languages/עברית.xaml
+++ b/YoutubePlaylistDownloader/Languages/עברית.xaml
@@ -156,4 +156,5 @@ the file convertion to 2, etc..</s:String>
     <s:String x:Key="Shorter">קצרים</s:String>
     <s:String x:Key="FileDoesNotExist">{0} לא קיים.</s:String>
     <s:String x:Key="Retry">נסה שוב</s:String>
+    <s:String x:Key="Of">of</s:String>
 </ResourceDictionary>

--- a/YoutubePlaylistDownloader/Languages/العربية.xaml
+++ b/YoutubePlaylistDownloader/Languages/العربية.xaml
@@ -156,4 +156,5 @@ the file convertion to 2, etc..</s:String>
     <s:String x:Key="Shorter">أقل </s:String>
     <s:String x:Key="FileDoesNotExist">غير موجود{0}</s:String>
     <s:String x:Key="Retry">Retry</s:String>
+    <s:String x:Key="Of">of</s:String>
 </ResourceDictionary> 

--- a/YoutubePlaylistDownloader/Languages/中文.xaml
+++ b/YoutubePlaylistDownloader/Languages/中文.xaml
@@ -140,4 +140,5 @@ the file convertion to 2, etc..</s:String>
     <s:String x:Key="Shorter">shorter</s:String>
     <s:String x:Key="FileDoesNotExist">{0} does not exist.</s:String>
     <s:String x:Key="Retry">Retry</s:String>
+    <s:String x:Key="Of">of</s:String>
 </ResourceDictionary>


### PR DESCRIPTION
Incorrect backslash was used, but I prefer to use 'of' instead of '/'. I think that, for example, "1 of 2" looks better than "1/2".