### PR TITLE
Removed unneeded dependency on deprecated LtGt library.

### DIFF
--- a/YoutubePlaylistDownloader/YoutubePlaylistDownloader.csproj
+++ b/YoutubePlaylistDownloader/YoutubePlaylistDownloader.csproj
@@ -79,7 +79,6 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="FParsec" Version="1.0.3" />
-		<PackageReference Include="LtGt" Version="1.0.2" />
 		<PackageReference Include="MahApps.Metro.Resources" Version="0.6.1.0" />
 		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
 		<PackageReference Include="morelinq" Version="2.10.0" />


### PR DESCRIPTION
The `LtGt` library is deprecated (see [here](https://www.nuget.org/packages/LtGt/) and [here](https://github.com/Tyrrrz/LtGt)) and **not used** directly by the `YoutubePlaylistDownloader`. This dependency is an artifact because of an indirect dependency from the `YoutubeExplode` library; `LtGt` was replaced by `AngleSharp` starting with `YoutubeExplode` version `5.0`.