### PR TITLE
Removed dependency on deprecated MahApps.Metro.Resources library.

### DIFF
--- a/YoutubePlaylistDownloader/YoutubePlaylistDownloader.csproj
+++ b/YoutubePlaylistDownloader/YoutubePlaylistDownloader.csproj
@@ -79,7 +79,6 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="FParsec" Version="1.0.3" />
-		<PackageReference Include="MahApps.Metro.Resources" Version="0.6.1.0" />
 		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
 		<PackageReference Include="morelinq" Version="2.10.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.2" />


### PR DESCRIPTION
Same as in the previous PR (#138). The `MahApps.Metro.Resources` library is deprecated (see [here](https://github.com/MahApps/MahApps.Metro.Resources)) and I think the functionality is provided by `MahApps.Metro.IconPacks` which is already installed.

Feel free to double-check, but I don't see any errors (or additional warnings) at the built time or at the run time (the UI looks fine) after removing the `MahApps.Metro.Resources` dependency.