### PR TITLE
Removed unused FParsec library.

### DIFF
--- a/YoutubePlaylistDownloader/YoutubePlaylistDownloader.csproj
+++ b/YoutubePlaylistDownloader/YoutubePlaylistDownloader.csproj
@@ -78,7 +78,6 @@
 		</BootstrapperPackage>
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="FParsec" Version="1.0.3" />
 		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
 		<PackageReference Include="morelinq" Version="2.10.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.2" />


### PR DESCRIPTION
I think this is the last one. The `FParsec` library was installed in commit 928fee4b58c330c52b4bbc356ac4dd62c2ce4dc4 (together with `FParsecCS` and `FSharp.Core`) when `YoutubeExplode` was updated from version `4.7.10` to `4.7.12`. I am not sure why (maybe an indirect dependency?), but certainly, this is not needed anymore.

I did a quick smoke test by downloading a video and everything seems fine.