### PR TITLE
added file format option for videos

### DIFF
--- a/YoutubePlaylistDownloader/DownloadPage.xaml.cs
+++ b/YoutubePlaylistDownloader/DownloadPage.xaml.cs
@@ -26,6 +26,7 @@ namespace YoutubePlaylistDownloader
         private readonly DownloadSettings downloadSettings;
         private FullPlaylist Playlist;
         private string FileType;
+        private string VideoFileTypes;
         private readonly string CaptionsLanguage;
         private int DownloadedCount;
         private readonly int StartIndex;
@@ -167,6 +168,7 @@ namespace YoutubePlaylistDownloader
             DownloadedVideosProgressBar.Maximum = Maximum;
             Playlist = playlist;
             FileType = settings.SaveFormat;
+            VideoFileTypes = settings.VideoSaveFormat;
             DownloadedCount = 0;
             Quality = settings.Quality;
             DownloadCaptions = settings.DownloadCaptions;
@@ -640,8 +642,8 @@ namespace YoutubePlaylistDownloader
 
                     var cleanVideoName = GlobalConsts.CleanFileName(downloadSettings.GetFilenameByPattern(video, i, title, Playlist));
                     var fileLoc = $"{GlobalConsts.TempFolderPath}{cleanVideoName}";
-                    var outputFileLoc = $"{GlobalConsts.TempFolderPath}{cleanVideoName}.mkv";
-                    var copyFileLoc = $"{SavePath}\\{cleanVideoName}.mkv";
+                    var outputFileLoc = $"{GlobalConsts.TempFolderPath}{cleanVideoName}.{VideoFileTypes}";
+                    var copyFileLoc = $"{SavePath}\\{cleanVideoName}.{VideoFileTypes}";
                     var audioLoc = $"{GlobalConsts.TempFolderPath}{cleanVideoName}.{bestAudio.Container.Name}";
                     var captionsLoc = $"{GlobalConsts.TempFolderPath}{cleanVideoName}.srt";
 
@@ -988,6 +990,7 @@ namespace YoutubePlaylistDownloader
                 disposedValue = true;
                 Videos = null;
                 FileType = null;
+                VideoFileTypes = null;
                 Bitrate = null;
                 NotDownloaded = null;
                 Videos = null;

--- a/YoutubePlaylistDownloader/DownloadSettingsControl.xaml
+++ b/YoutubePlaylistDownloader/DownloadSettingsControl.xaml
@@ -36,6 +36,8 @@
                     <StackPanel Orientation="Horizontal" >
                         <CheckBox Content="{DynamicResource Prefer}" Margin="7" x:Name="PreferCheckBox" HorizontalAlignment="Center" IsChecked="False"  />
                         <ComboBox HorizontalContentAlignment="Left" HorizontalAlignment="Center" VerticalContentAlignment="Center" Width="Auto" x:Name="ResulotionDropDown" VerticalAlignment="Center"/>
+                        <Label Content="{DynamicResource FormatOf}" />
+                        <ComboBox HorizontalContentAlignment="Left" HorizontalAlignment="Center" VerticalContentAlignment="Center" Width="Auto" x:Name="VideoExtensionsDropDown" VerticalAlignment="Center"/>
                     </StackPanel>
                     <CheckBox Margin="7" x:Name="PreferHighestFPSCheckBox" Content="{DynamicResource PreferFPS}" />
                     <CheckBox x:Name="CaptionsCheckBox" Margin="7" Content="{DynamicResource DownloadCaptions}" />

--- a/YoutubePlaylistDownloader/DownloadSettingsControl.xaml.cs
+++ b/YoutubePlaylistDownloader/DownloadSettingsControl.xaml.cs
@@ -27,6 +27,7 @@ namespace YoutubePlaylistDownloader
             { "3072p", YoutubeHelpers.High3072 },
             { "4320p", YoutubeHelpers.High4320 }
         };
+        private readonly string[] VideoFileTypes = { "mp4", "mkv"};
 
         private readonly string[] FileTypes = { "mp3", "aac", "opus", "wav", "flac", "m4a", "ogg", "webm" };
 
@@ -39,12 +40,14 @@ namespace YoutubePlaylistDownloader
             InitializeComponent();
 
             ResulotionDropDown.ItemsSource = Resolutions.Keys;
+            VideoExtensionsDropDown.ItemsSource = VideoFileTypes;
             ExtensionsDropDown.ItemsSource = FileTypes;
             CaptionsLanguagesComboBox.ItemsSource = Languages.Values;
 
             var settings = GlobalConsts.DownloadSettings;
             SaveDirectoryTextBox.Text = GlobalConsts.settings.SaveDirectory;
             ExtensionsDropDown.SelectedItem = settings.SaveFormat;
+            VideoExtensionsDropDown.SelectedItem = settings.VideoSaveFormat;
             ResulotionDropDown.SelectedItem = Resolutions.FirstOrDefault(x => x.Value == settings.Quality).Key;
             PreferCheckBox.IsChecked = settings.PreferQuality;
             PreferHighestFPSCheckBox.IsChecked = settings.PreferHighestFPS;
@@ -85,6 +88,7 @@ namespace YoutubePlaylistDownloader
             ConvertCheckBox.Checked += ConvertCheckBox_Checked;
             ConvertCheckBox.Unchecked += ConvertCheckBox_Unchecked;
             ExtensionsDropDown.SelectionChanged += ExtensionsDropDown_SelectionChanged;
+            VideoExtensionsDropDown.SelectionChanged += VideoExtensionsDropDown_SelectionChanged;
             BitrateCheckBox.Checked += BitrateCheckBox_Checked;
             BitrateCheckBox.Unchecked += BitrateCheckBox_Unchecked;
             BitRateTextBox.TextChanged += BitRateTextBox_TextChanged;
@@ -334,6 +338,7 @@ namespace YoutubePlaylistDownloader
             {
                 GlobalConsts.DownloadSettings.Convert = ConvertCheckBox.IsChecked.Value;
                 GlobalConsts.DownloadSettings.SaveFormat = (string)ExtensionsDropDown.SelectedItem;
+                GlobalConsts.DownloadSettings.VideoSaveFormat = (string)VideoExtensionsDropDown.SelectedItem;
                 GlobalConsts.SaveDownloadSettings();
             }
         }
@@ -352,6 +357,15 @@ namespace YoutubePlaylistDownloader
             if (GlobalConsts.settings.SaveDownloadOptions)
             {
                 GlobalConsts.DownloadSettings.SaveFormat = (string)ExtensionsDropDown.SelectedItem;
+                GlobalConsts.SaveDownloadSettings();
+            }
+        }
+
+        private void VideoExtensionsDropDown_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (GlobalConsts.settings.SaveDownloadOptions)
+            {
+                GlobalConsts.DownloadSettings.VideoSaveFormat = (string)VideoExtensionsDropDown.SelectedItem;
                 GlobalConsts.SaveDownloadSettings();
             }
         }

--- a/YoutubePlaylistDownloader/GlobalConsts.cs
+++ b/YoutubePlaylistDownloader/GlobalConsts.cs
@@ -57,7 +57,7 @@ namespace YoutubePlaylistDownloader
         {
             get
             {
-                downloadSettings ??= new DownloadSettings("mp3", false, YoutubeHelpers.High720, false, false, false, false, "192", false, "en", false, false, 0, 0, false, true, false, true, 4, "$title", false);
+                downloadSettings ??= new DownloadSettings("mp4", "mp3", false, YoutubeHelpers.High720, false, false, false, false, "192", false, "en", false, false, 0, 0, false, true, false, true, 4, "$title", false);
 
                 return downloadSettings;
             }
@@ -181,7 +181,7 @@ namespace YoutubePlaylistDownloader
         {
             Log("Restoring defaults", "RestoreDefaults at GlobalConsts").Wait();
             settings = new Objects.Settings("Dark", "Red", "English", Environment.GetFolderPath(Environment.SpecialFolder.MyVideos), false, false, true, TimeSpan.FromMinutes(1), true, 20, 2, true, true);
-            DownloadSettings = new DownloadSettings("mp3", false, YoutubeHelpers.High720, false, false, false, false, "192", false, "en", false, false, 0, 0, false, true, false, true, 4, "$title", false);
+            DownloadSettings = new DownloadSettings("mp4", "mp3", false, YoutubeHelpers.High720, false, false, false, false, "192", false, "en", false, false, 0, 0, false, true, false, true, 4, "$title", false);
             SaveConsts();
         }
         public static void LoadConsts()
@@ -530,12 +530,12 @@ namespace YoutubePlaylistDownloader
                     {
                         Log(ex2.ToString(), "Delete download settings file path").Wait();
                     }
-                    downloadSettings = new DownloadSettings("mp3", false, YoutubeHelpers.High720, false, false, false, false, "192", false, "en", false, false, 0, 0, false, true, false, true, 4, "$title", false);
+                    downloadSettings = new DownloadSettings("mp4" ,"mp3", false, YoutubeHelpers.High720, false, false, false, false, "192", false, "en", false, false, 0, 0, false, true, false, true, 4, "$title", false);
                 }
             }
             else
             {
-                downloadSettings = new DownloadSettings("mp3", false, YoutubeHelpers.High720, false, false, false, false, "192", false, "en", false, false, 0, 0, false, true, false, true, 4, "$title", false);
+                downloadSettings = new DownloadSettings("mp4", "mp3", false, YoutubeHelpers.High720, false, false, false, false, "192", false, "en", false, false, 0, 0, false, true, false, true, 4, "$title", false);
             }
         }
         public static void SaveDownloadSettings()

--- a/YoutubePlaylistDownloader/Languages/Deutsch.xaml
+++ b/YoutubePlaylistDownloader/Languages/Deutsch.xaml
@@ -30,6 +30,7 @@
     <s:String x:Key="Videos">Videos</s:String>
     <s:String x:Key="Download">Download</s:String>
     <s:String x:Key="ConvertToMp3">Konvertieren von Videos zu </s:String>
+    <s:String x:Key="FormatOf">and format of</s:String>
     <s:String x:Key="StillConverting">Wird konvertiert</s:String>
     <s:String x:Key="files">Dateien</s:String>
     <s:String x:Key="Author">Autor: </s:String>

--- a/YoutubePlaylistDownloader/Languages/English.xaml
+++ b/YoutubePlaylistDownloader/Languages/English.xaml
@@ -30,6 +30,7 @@
     <s:String x:Key="Videos">Videos</s:String>
     <s:String x:Key="Download">Download</s:String>
     <s:String x:Key="ConvertToMp3">Convert videos to</s:String>
+    <s:String x:Key="FormatOf">and format of</s:String>
     <s:String x:Key="StillConverting">Still converting</s:String>
     <s:String x:Key="files">files</s:String>
     <s:String x:Key="Author">Author: </s:String>

--- a/YoutubePlaylistDownloader/Languages/Español.xaml
+++ b/YoutubePlaylistDownloader/Languages/Español.xaml
@@ -30,6 +30,7 @@
     <s:String x:Key="Videos">Videos</s:String>
     <s:String x:Key="Download">Descargar</s:String>
     <s:String x:Key="ConvertToMp3">Convertir videos a </s:String>
+    <s:String x:Key="FormatOf">and format of</s:String>
     <s:String x:Key="StillConverting">Todavía se estan convirtiendo</s:String>
     <s:String x:Key="files">videos</s:String>
     <s:String x:Key="Author">Autor: </s:String>

--- a/YoutubePlaylistDownloader/Languages/Français.xaml
+++ b/YoutubePlaylistDownloader/Languages/Français.xaml
@@ -30,6 +30,7 @@
     <s:String x:Key="Videos">Vidéos</s:String>
     <s:String x:Key="Download">Téléchargement</s:String>
     <s:String x:Key="ConvertToMp3">Convertir des vidéos en </s:String>
+    <s:String x:Key="FormatOf">and format of</s:String>
     <s:String x:Key="StillConverting">Conversion en cours</s:String>
     <s:String x:Key="files">fichier</s:String>
     <s:String x:Key="Author">Auteur: </s:String>

--- a/YoutubePlaylistDownloader/Languages/Italiano.xaml
+++ b/YoutubePlaylistDownloader/Languages/Italiano.xaml
@@ -30,6 +30,7 @@
     <s:String x:Key="Videos">Video</s:String>
     <s:String x:Key="Download">Download</s:String>
     <s:String x:Key="ConvertToMp3">Converti i video in </s:String>
+    <s:String x:Key="FormatOf">and format of</s:String>
     <s:String x:Key="StillConverting">Sto ancora convertendo</s:String>
     <s:String x:Key="files">File</s:String>
     <s:String x:Key="Author">Autore: </s:String>

--- a/YoutubePlaylistDownloader/Languages/Polski.xaml
+++ b/YoutubePlaylistDownloader/Languages/Polski.xaml
@@ -30,6 +30,7 @@
     <s:String x:Key="Videos">Filmy</s:String>
     <s:String x:Key="Download">Pobierz</s:String>
     <s:String x:Key="ConvertToMp3">Konwertuj pliki do</s:String>
+    <s:String x:Key="FormatOf">and format of</s:String>
     <s:String x:Key="StillConverting">Wciąż konvertuję</s:String>
     <s:String x:Key="files">pliki</s:String>
     <s:String x:Key="Author">Autor: </s:String>

--- a/YoutubePlaylistDownloader/Languages/Português (BR).xaml
+++ b/YoutubePlaylistDownloader/Languages/Português (BR).xaml
@@ -30,6 +30,7 @@
     <s:String x:Key="Videos">Vídeos</s:String>
     <s:String x:Key="Download">Download</s:String>
     <s:String x:Key="ConvertToMp3">Converter vídeos para </s:String>
+    <s:String x:Key="FormatOf">and format of</s:String>
     <s:String x:Key="StillConverting">Ainda convertendo</s:String>
     <s:String x:Key="files">Arquivos</s:String>
     <s:String x:Key="Author">Autor: </s:String>

--- a/YoutubePlaylistDownloader/Languages/Türkçe.xaml
+++ b/YoutubePlaylistDownloader/Languages/Türkçe.xaml
@@ -30,6 +30,7 @@
     <s:String x:Key="Videos">Videolar</s:String>
     <s:String x:Key="Download">İndir</s:String>
     <s:String x:Key="ConvertToMp3">Videoyu Dönüştür </s:String>
+    <s:String x:Key="FormatOf">and format of</s:String>
     <s:String x:Key="StillConverting">Dönüştürülüyor</s:String>
     <s:String x:Key="files">dosyalar</s:String>
     <s:String x:Key="Author">Yazar: </s:String>

--- a/YoutubePlaylistDownloader/Languages/עברית.xaml
+++ b/YoutubePlaylistDownloader/Languages/עברית.xaml
@@ -29,6 +29,7 @@
     <s:String x:Key="Videos">סרטונים</s:String>
     <s:String x:Key="Download">הורד</s:String>
     <s:String x:Key="ConvertToMp3">המר את הסרטונים ל </s:String>
+    <s:String x:Key="FormatOf">and format of</s:String>
     <s:String x:Key="StillConverting">עדיין ממיר</s:String>
     <s:String x:Key="files">קבצים</s:String>
     <s:String x:Key="Author">בעלים: </s:String>

--- a/YoutubePlaylistDownloader/Languages/العربية.xaml
+++ b/YoutubePlaylistDownloader/Languages/العربية.xaml
@@ -30,6 +30,7 @@
     <s:String x:Key="Videos">مقاطع الفيديو </s:String>
     <s:String x:Key="Download">تحميل </s:String>
     <s:String x:Key="ConvertToMp3"> تحويل الفيديو الى </s:String>
+    <s:String x:Key="FormatOf">and format of</s:String>
     <s:String x:Key="StillConverting">لا يزال قيد التحويل </s:String>
     <s:String x:Key="files">الملفات</s:String>
     <s:String x:Key="Author">:المؤلف</s:String>

--- a/YoutubePlaylistDownloader/Languages/中文.xaml
+++ b/YoutubePlaylistDownloader/Languages/中文.xaml
@@ -30,6 +30,7 @@
     <s:String x:Key="Videos">视频</s:String>
     <s:String x:Key="Download">下载</s:String>
     <s:String x:Key="ConvertToMp3">转换视频成 </s:String>
+    <s:String x:Key="FormatOf">and format of</s:String>
     <s:String x:Key="StillConverting">还转变</s:String>
     <s:String x:Key="files">文件</s:String>
     <s:String x:Key="Author">作者: </s:String>

--- a/YoutubePlaylistDownloader/MainPage.xaml.cs
+++ b/YoutubePlaylistDownloader/MainPage.xaml.cs
@@ -36,6 +36,7 @@ namespace YoutubePlaylistDownloader
             { "3072p", YoutubeHelpers.High3072 },
             { "4320p", YoutubeHelpers.High4320 }
         };
+        private readonly string[] VideoFileTypes = { "mp4", "mkv"};
 
         private readonly string[] FileTypes = { "mp3", "aac", "opus", "wav", "flac", "m4a", "ogg", "webm" };
 

--- a/YoutubePlaylistDownloader/Objects/DownloadSettings.cs
+++ b/YoutubePlaylistDownloader/Objects/DownloadSettings.cs
@@ -14,6 +14,9 @@ namespace YoutubePlaylistDownloader.Objects
         public string SavePath { get; set; }
 
         [JsonProperty]
+        public string VideoSaveFormat { get; set; }
+
+        [JsonProperty]
         public string SaveFormat { get; set; }
 
         [JsonProperty]
@@ -85,12 +88,13 @@ namespace YoutubePlaylistDownloader.Objects
 
 
 		[JsonConstructor]
-        public DownloadSettings(string saveForamt, bool audioOnly, VideoQuality quality, bool preferHighestFPS,
+        public DownloadSettings(string videoSaveFormat, string saveFormat, bool audioOnly, VideoQuality quality, bool preferHighestFPS,
             bool preferQuality, bool convert, bool setBitrate, string bitrate, bool downloadCaptions, string captionsLanguage,
             bool savePlaylistsInDifferentDirectories, bool subset, int subsetStartIndex, int subsetEndIndex, bool openDestinationFolderWhenDone,
             bool tagAudioFile, bool filterVideosByLength, bool filterMode, double filterByLengthValue, string filenamePattern, bool skipExisting)
         {
-            SaveFormat = saveForamt;
+            VideoSaveFormat = videoSaveFormat;
+            SaveFormat = saveFormat;
             AudioOnly = audioOnly;
             Quality = quality;
             PreferHighestFPS = preferHighestFPS;
@@ -115,6 +119,7 @@ namespace YoutubePlaylistDownloader.Objects
 
         public DownloadSettings(DownloadSettings settings)
         {
+            VideoSaveFormat = settings.VideoSaveFormat;
             SaveFormat = settings.SaveFormat;
             AudioOnly = settings.AudioOnly;
             Quality = settings.Quality;


### PR DESCRIPTION
This change resolves #155 by adding an option for the file extension for video downloads, There are 2 options - mp4 and mkv.
There is one more problem though, I didn't translate a few words i have added into respective languages.
signed-off-by: MaheshPaul (CityIsBetter) <mahesh.paul.j@gmail.com>