### PR TITLE
Fixed version numbering.

### DIFF
--- a/YoutubePlaylistDownloader/GlobalConsts.cs
+++ b/YoutubePlaylistDownloader/GlobalConsts.cs
@@ -36,7 +36,7 @@ namespace YoutubePlaylistDownloader
         public static readonly string FFmpegFilePath;
         private static readonly string ConfigFilePath;
         private static readonly string ErrorFilePath;
-        public static readonly Version VERSION = new(1, 9, 20);
+        public static readonly Version VERSION = new(1, 9, 21);
         public static bool UpdateOnExit;
         public static string UpdateSetupLocation;
         public static bool UpdateFinishedDownloading;


### PR DESCRIPTION
The app shows incorrectly (even when built from the latest commit) that a new version is available.

![image](https://github.com/shaked6540/YoutubePlaylistDownloader/assets/12585988/66f88273-5bed-4828-9687-4df01867c3dc)
