### PR TITLE
Fixed an issue with downloading single video files

### DIFF
--- a/YoutubePlaylistDownloader/GlobalConsts.cs
+++ b/YoutubePlaylistDownloader/GlobalConsts.cs
@@ -383,7 +383,7 @@ static class GlobalConsts
         return $"{string.Join(", ", artists)} - {title}";
     }
 
-    public static async Task<string> TagFileBasedOnTitle(PlaylistVideo video, int vIndex, string file, FullPlaylist playlist = null)
+    public static async Task<string> TagFileBasedOnTitle(IVideo video, int vIndex, string file, FullPlaylist playlist = null)
     {
         var genre = video.Title.Split('[', ']').ElementAtOrDefault(1);
         if (genre == null)
@@ -450,7 +450,7 @@ static class GlobalConsts
         return file;
     }
 
-    public static async Task<string> TagFile(PlaylistVideo video, int vIndex, string file, FullPlaylist playlist = null)
+    public static async Task<string> TagFile(IVideo video, int vIndex, string file, FullPlaylist playlist = null)
     {
         ArgumentNullException.ThrowIfNull(video);
 

--- a/YoutubePlaylistDownloader/MainPage.xaml.cs
+++ b/YoutubePlaylistDownloader/MainPage.xaml.cs
@@ -4,7 +4,7 @@ public partial class MainPage : UserControl
 {
     private readonly YoutubeClient client;
     private FullPlaylist list = null;
-    private IEnumerable<PlaylistVideo> VideoList;
+    private IEnumerable<IVideo> VideoList;
     private Channel channel = null;
     private readonly Dictionary<string, VideoQuality> Resolutions = new()
     {
@@ -32,7 +32,7 @@ public partial class MainPage : UserControl
         GlobalConsts.ShowSettingsButton();
         GlobalConsts.ShowAboutButton();
         GlobalConsts.ShowHelpButton();
-        VideoList = new List<PlaylistVideo>();
+        VideoList = new List<IVideo>();
         client = GlobalConsts.YoutubeClient;
 
         GlobalConsts.MainPage = this;
@@ -55,7 +55,7 @@ public partial class MainPage : UserControl
             {
                 _ = Task.Run(async () =>
                 {
-                    var basePlaylist = await client.Playlists.GetAsync(playlistId).ConfigureAwait(false);
+                    var basePlaylist = await client.Playlists.GetAsync(playlistId.Value).ConfigureAwait(false);
                     list = new FullPlaylist(basePlaylist, await client.Playlists.GetVideosAsync(basePlaylist.Id).CollectAsync().ConfigureAwait(false));
                     VideoList = new List<PlaylistVideo>();
                     await UpdatePlaylistInfo(Visibility.Visible, list.BasePlaylist.Title, list.BasePlaylist.Author?.ChannelTitle ?? "", "", list.Videos.Count().ToString(), $"https://img.youtube.com/vi/{list?.Videos?.FirstOrDefault()?.Id}/maxresdefault.jpg", true, true);
@@ -96,7 +96,7 @@ public partial class MainPage : UserControl
                 _ = Task.Run(async () =>
                 {
                     var video = await client.Videos.GetAsync(videoId);
-                    VideoList = new List<PlaylistVideo> { new(playlistId, video.Id, video.Title, video.Author, video.Duration, video.Thumbnails) };
+                    VideoList = new List<Video> { video };
                     list = new FullPlaylist(null, null);
                     await UpdatePlaylistInfo(Visibility.Visible, video.Title, video.Author.ChannelTitle, video.Engagement.ViewCount.ToString(), string.Empty, $"https://img.youtube.com/vi/{video.Id}/maxresdefault.jpg", true, false);
 
@@ -126,7 +126,7 @@ public partial class MainPage : UserControl
             }
 
             GlobalConsts.LoadPage(new DownloadPage(list, GlobalConsts.DownloadSettings.Clone(), videos: VideoList));
-            VideoList = new List<PlaylistVideo>();
+            VideoList = new List<IVideo>();
             PlaylistLinkTextBox.Text = string.Empty;
         }
     }
@@ -175,7 +175,7 @@ public partial class MainPage : UserControl
             }
 
             _ = new DownloadPage(list, GlobalConsts.DownloadSettings.Clone(), silent: true, videos: VideoList);
-            VideoList = new List<PlaylistVideo>();
+            VideoList = new List<IVideo>();
             PlaylistLinkTextBox.Text = string.Empty;
         }
     }

--- a/YoutubePlaylistDownloader/Objects/DownloadSettings.cs
+++ b/YoutubePlaylistDownloader/Objects/DownloadSettings.cs
@@ -138,7 +138,7 @@ public class DownloadSettings
         VideoSaveFormat = settings.VideoSaveFormat;
     }
 
-    public string GetFilenameByPattern(PlaylistVideo video, int vIndex, string file, FullPlaylist playlist = null)
+    public string GetFilenameByPattern(IVideo video, int vIndex, string file, FullPlaylist playlist = null)
     {
         if (video == null)
             return file;

--- a/YoutubePlaylistDownloader/Objects/FullPlaylist.cs
+++ b/YoutubePlaylistDownloader/Objects/FullPlaylist.cs
@@ -1,9 +1,9 @@
 ﻿namespace YoutubePlaylistDownloader.Objects;
 
-public class FullPlaylist(Playlist basePlaylist, IEnumerable<PlaylistVideo> videos, string title = null)
+public class FullPlaylist(Playlist basePlaylist, IEnumerable<IVideo> videos, string title = null)
 {
     public Playlist BasePlaylist { get; private set; } = basePlaylist;
-    public IEnumerable<PlaylistVideo> Videos { get; private set; } = videos;
+    public IEnumerable<IVideo> Videos { get; private set; } = videos;
 
     public string Title { get; private set; } = basePlaylist?.Title ?? title;
 }

--- a/YoutubePlaylistDownloader/Utilities/YoutubeHelpers.cs
+++ b/YoutubePlaylistDownloader/Utilities/YoutubeHelpers.cs
@@ -61,7 +61,7 @@ public static partial class YoutubeHelpers
     /// <summary>
     /// Tries to parse playlist ID from a YouTube playlist URL.
     /// </summary>
-    public static bool TryParsePlaylistId(string playlistUrl, out string playlistId)
+    public static bool TryParsePlaylistId(string playlistUrl, out PlaylistId? playlistId)
     {
         playlistId = default;
 
@@ -72,7 +72,7 @@ public static partial class YoutubeHelpers
         var regularMatch = RegularRegex().Match(playlistUrl).Groups[1].Value;
         if (!string.IsNullOrWhiteSpace(regularMatch) && ValidatePlaylistId(regularMatch))
         {
-            playlistId = regularMatch;
+            playlistId = PlaylistId.Parse(regularMatch);
             return true;
         }
 
@@ -80,7 +80,7 @@ public static partial class YoutubeHelpers
         var compositeMatch = CompositeRegex().Match(playlistUrl).Groups[1].Value;
         if (!string.IsNullOrWhiteSpace(compositeMatch) && ValidatePlaylistId(compositeMatch))
         {
-            playlistId = compositeMatch;
+            playlistId = PlaylistId.Parse(compositeMatch);
             return true;
         }
 
@@ -88,7 +88,7 @@ public static partial class YoutubeHelpers
         var shortCompositeMatch = ShortLinkRegex().Match(playlistUrl).Groups[1].Value;
         if (!string.IsNullOrWhiteSpace(shortCompositeMatch) && ValidatePlaylistId(shortCompositeMatch))
         {
-            playlistId = shortCompositeMatch;
+            playlistId = PlaylistId.Parse(shortCompositeMatch);
             return true;
         }
 
@@ -96,7 +96,7 @@ public static partial class YoutubeHelpers
         var embedCompositeMatch = EmbedRegex().Match(playlistUrl).Groups[1].Value;
         if (!string.IsNullOrWhiteSpace(embedCompositeMatch) && ValidatePlaylistId(embedCompositeMatch))
         {
-            playlistId = embedCompositeMatch;
+            playlistId = PlaylistId.Parse(embedCompositeMatch);
             return true;
         }
 

--- a/YoutubePlaylistDownloader/YoutubePlaylistDownloader.csproj
+++ b/YoutubePlaylistDownloader/YoutubePlaylistDownloader.csproj
@@ -75,7 +75,7 @@
     </PackageReference>
     <PackageReference Include="MahApps.Metro" Version="2.4.9" />
     <PackageReference Include="MahApps.Metro.IconPacks" Version="4.11.0" />
-    <PackageReference Include="YoutubeExplode" Version="6.3.12" />
+    <PackageReference Include="YoutubeExplode" Version="6.3.13" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />


### PR DESCRIPTION
Updated YoutubeExplode library to the latest version (6.3.13);

Refactored code to use IVideo interface instead of PlaylistVideo when possible;
Fixed an issue when downloading single video files (when playlistId is null YoutubeExplode throws 'Invalid YouTube playlist ID or URL').

**NOTE**: Do not merge this yet as it requires more testing.

Possible fixes for #224, #225, and #238.