### PR TITLE
Fixed incorrect index in filenames when converting videos to audio

### DIFF
--- a/YoutubePlaylistDownloader/DownloadPage.xaml.cs
+++ b/YoutubePlaylistDownloader/DownloadPage.xaml.cs
@@ -416,7 +416,8 @@ public partial class DownloadPage : UserControl, IDisposable, IDownload
 
                                 if (TagAudioFile)
                                 {
-                                    var afterTagName = await GlobalConsts.TagFile(video, indexes[video], outputFileLoc, Playlist);
+                                    var videoIndex = indexes[video];
+                                    var afterTagName = await GlobalConsts.TagFile(video, videoIndex, outputFileLoc, Playlist);
                                     FileType = new string(copyFileLoc.Skip(copyFileLoc.LastIndexOf('.') + 1).ToArray());
                                     if (afterTagName != outputFileLoc)
                                     {
@@ -425,7 +426,7 @@ public partial class DownloadPage : UserControl, IDisposable, IDownload
                                             video = new PlaylistVideo(playlistId.Value, video.Id, afterTagName, video.Author, video.Duration, video.Thumbnails);
                                         }
 
-                                        cleanFileName = GlobalConsts.CleanFileName(downloadSettings.GetFilenameByPattern(video, i, title, Playlist));
+                                        cleanFileName = GlobalConsts.CleanFileName(downloadSettings.GetFilenameByPattern(video, videoIndex - 1, title, Playlist));
                                         copyFileLoc = $"{SavePath}\\{cleanFileName}.{FileType}";
                                     }
                                 }


### PR DESCRIPTION
When converting playlist videos to audio the index in the filename was arbitrarily assigned (due to variable reuse in async tasks). This was regardless of the maximum concurrent file conversions setting.

URL used for testing: https://www.youtube.com/watch?v=uFLoZ-gr4PE&list=OLAK5uy_nLwrcZJLKqwkwW1k3GLuic1hA9NUchja8&index=5

YoutubePlaylistDownloader settings to reproduce the issue:
* File name pattern: $index $title
* Convert videos to mp3 and set the bit rate to 320 kbps
* Set the maximum concurrent file conversions to 1.

**Before the fix (maximum concurrent file conversions was set to 1)**
https://github.com/shaked6540/YoutubePlaylistDownloader/assets/12585988/3d4f6bd7-139a-408b-9315-04785e2e524e

**After the fix (maximum concurrent file conversions was set to 1)**
https://github.com/shaked6540/YoutubePlaylistDownloader/assets/12585988/69bb506b-a085-400f-837a-480d2e805d75

**After the fix (maximum concurrent file conversions was set to 3)**
https://github.com/shaked6540/YoutubePlaylistDownloader/assets/12585988/3ad7bc5f-ecfa-487a-ad1e-2a380c42fa56

