### PR TITLE
Partial revert of eaaa55ee8d290a39c2204e42f2f3ad73a6bff925 to fix YoutubeExplode version.

### DIFF
--- a/YoutubePlaylistDownloader/YoutubePlaylistDownloader.csproj
+++ b/YoutubePlaylistDownloader/YoutubePlaylistDownloader.csproj
@@ -75,10 +75,10 @@
     </PackageReference>
     <PackageReference Include="MahApps.Metro" Version="2.4.9" />
     <PackageReference Include="MahApps.Metro.IconPacks" Version="4.11.0" />
+    <PackageReference Include="YoutubeExplode" Version="6.3.13" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="YoutubeExplode" Version="6.1.14" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Properties\Settings.Designer.cs">


### PR DESCRIPTION
**Note**: I think version 1.9.24 setup/release is broken because it comes with an older version (6.1.14) of YoutubeExplode instead of the last one (6.3.13).