### PR TITLE
Updated the installer file to use relative paths within the parent folder.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -299,4 +299,5 @@ __pycache__/
 *.xsd.cs
 
 YoutubePlaylistDownloader/ffmpeg.exe
-YoutubePlaylistDownloader/taglib-sharp.dll
+/Installer Output/
+/FFmpeg/

--- a/YPDSetup/YPDSetup.iss
+++ b/YPDSetup/YPDSetup.iss
@@ -16,7 +16,7 @@ AppUpdatesURL=https://github.com/shaked6540/YoutubePlaylistDownloader
 DefaultDirName={commonpf}\YouTube Playlist Downloader
 DefaultGroupName=YouTube Playlist Downloader
 AllowNoIcons=yes
-OutputDir=D:\Inno output\1.9.24
+OutputDir=..\Installer Output\1.9.24\
 OutputBaseFilename=YoutubePlaylistDownloader
 SetupIconFile=..\YoutubePlaylistDownloader\finalIcon.ico
 Compression=lzma
@@ -32,7 +32,7 @@ Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{
 
 [Files]
 Source: "..\YoutubePlaylistDownloader\bin\Release\net8.0-windows\*"; DestDir: "{app}"; Flags: ignoreversion
-Source: "C:\bin\bin32\ffmpeg.exe"; DestDir: "{app}"; Flags: ignoreversion
+Source: "..\FFmpeg\ffmpeg.exe"; DestDir: "{app}"; Flags: ignoreversion
 
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files        
 


### PR DESCRIPTION
This is nice to have to be able to build the installer easily as everything is contained within the parent folder and not depending on some specific folder paths to exist.

The only change is that you only need to do on your side (i.e. on your local machine) is to create a FFmpeg folder and to put `ffmpeg.exe` into it for the installer to pick it up. I think that this folder can also be used as a source to copy the `ffmpeg.exe` into the build folder when building the solution, but I will look into this later.