### PR TITLE
Updated YoutubeExplode library to the latest version (6.4.2)

### DIFF
--- a/YoutubePlaylistDownloader/YoutubePlaylistDownloader.csproj
+++ b/YoutubePlaylistDownloader/YoutubePlaylistDownloader.csproj
@@ -75,7 +75,7 @@
     </PackageReference>
     <PackageReference Include="MahApps.Metro" Version="2.4.10" />
     <PackageReference Include="MahApps.Metro.IconPacks" Version="4.11.0" />
-    <PackageReference Include="YoutubeExplode" Version="6.3.13" />
+    <PackageReference Include="YoutubeExplode" Version="6.4.2" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.3" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />


### PR DESCRIPTION
Updated YoutubeExplode library to the latest version (6.4.2); Fixes #354 (and all the other duplicated issues).