### PR TITLE
Updated libraries to the latest version.

### DIFF
--- a/YoutubePlaylistDownloader/YoutubePlaylistDownloader.csproj
+++ b/YoutubePlaylistDownloader/YoutubePlaylistDownloader.csproj
@@ -68,16 +68,16 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="morelinq" Version="4.1.0" />
+    <PackageReference Include="MahApps.Metro.IconPacks.Modern" Version="5.0.0" />
+    <PackageReference Include="morelinq" Version="4.3.0" />
     <PackageReference Include="taglib-sharp-netstandard2.0" Version="2.1.0" />
     <PackageReference Include="Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers" Version="0.4.421302">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="MahApps.Metro" Version="2.4.10" />
-    <PackageReference Include="MahApps.Metro.IconPacks" Version="4.11.0" />
     <PackageReference Include="YoutubeExplode" Version="6.4.3" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.3" />
+    <PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.10" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Updated libraries to the latest version.
Replaced MahApps.Metro.IconPacks package with MahApps.Metro.IconPacks.Modern since only this icon pack is used. This will also reduce the number of transitive dependencies resulting in a smaller installer.

Note that the resulting installer is about 12% smaller (36.9 MB vs. 42.1 MB).

![image](https://github.com/user-attachments/assets/4502c83b-16c6-4b53-a1ee-aaf554d12f81)
