### PR TITLE
Improved UI when using a language other than English

### DIFF
--- a/YoutubePlaylistDownloader/About.xaml
+++ b/YoutubePlaylistDownloader/About.xaml
@@ -24,9 +24,11 @@
 
         </Controls:MetroTabControl>
 
-        <Controls:Tile Style="{DynamicResource LargeTileStyle}" x:Name="UpdateButton" Title="{DynamicResource CheckForUpdates}" Click="UpdateButton_Click">
-            <iconPacks:PackIconModern Width="40" Height="40" Kind="Inbox" />
-        </Controls:Tile>
+        <WrapPanel HorizontalAlignment="Center">
+            <Controls:Tile Style="{DynamicResource LargeTileStyle}" x:Name="UpdateButton" Title="{DynamicResource CheckForUpdates}" MinWidth="200" Width="Auto" HorizontalTitleAlignment="Center" Click="UpdateButton_Click">
+                <iconPacks:PackIconModern Width="40" Height="40" Kind="Inbox" />
+            </Controls:Tile>
+        </WrapPanel>
 
     </StackPanel>
 

--- a/YoutubePlaylistDownloader/DownloadPage.xaml
+++ b/YoutubePlaylistDownloader/DownloadPage.xaml
@@ -24,13 +24,13 @@
 
 
         <WrapPanel HorizontalAlignment="Center">
-            <Controls:Tile Click="Exit_Click" HorizontalAlignment="Center" Title="{DynamicResource Back}" Margin="5" Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2" Controls:ControlsHelper.MouseOverBorderBrush="{DynamicResource BlackBrush}"  HorizontalTitleAlignment="Right" Style="{StaticResource LargeTileStyle}">
+            <Controls:Tile Click="Exit_Click" HorizontalAlignment="Center" Title="{DynamicResource Back}" Margin="5" Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2" MinWidth="200" Width="Auto" HorizontalTitleAlignment="Center" Controls:ControlsHelper.MouseOverBorderBrush="{DynamicResource BlackBrush}" Style="{StaticResource LargeTileStyle}">
                 <iconPacks:PackIconModern Width="40" Height="40" Kind="ArrowLeft" />
             </Controls:Tile>
-            <Controls:Tile Click="Background_Exit" HorizontalAlignment="Center" Title="{DynamicResource DownloadInBackground}" Margin="5" Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2" Controls:ControlsHelper.MouseOverBorderBrush="{DynamicResource BlackBrush}"  HorizontalTitleAlignment="Right" Style="{StaticResource LargeTileStyle}">
+            <Controls:Tile Click="Background_Exit" HorizontalAlignment="Center" Title="{DynamicResource DownloadInBackground}" Margin="5" Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2" MinWidth="200" Width="Auto" HorizontalTitleAlignment="Center" Controls:ControlsHelper.MouseOverBorderBrush="{DynamicResource BlackBrush}" Style="{StaticResource LargeTileStyle}">
                 <iconPacks:PackIconModern Width="40" Height="40" Kind="InboxIn" />
             </Controls:Tile>
-            <Controls:Tile Click="OpenFolder_Click" HorizontalAlignment="Center" Title="{DynamicResource OpenDestinationFolder}" Margin="5" Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2" Controls:ControlsHelper.MouseOverBorderBrush="{DynamicResource BlackBrush}"  HorizontalTitleAlignment="Right" Style="{StaticResource LargeTileStyle}">
+            <Controls:Tile Click="OpenFolder_Click" HorizontalAlignment="Center" Title="{DynamicResource OpenDestinationFolder}" Margin="5" Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2" MinWidth="200" Width="Auto" HorizontalTitleAlignment="Center" Controls:ControlsHelper.MouseOverBorderBrush="{DynamicResource BlackBrush}" Style="{StaticResource LargeTileStyle}">
                 <iconPacks:PackIconModern Width="40" Height="40" Kind="FolderOpen" />
             </Controls:Tile>
         </WrapPanel>

--- a/YoutubePlaylistDownloader/DownloadSettingsControl.xaml
+++ b/YoutubePlaylistDownloader/DownloadSettingsControl.xaml
@@ -25,7 +25,7 @@
                     <StackPanel Orientation="Horizontal">
                         <Label Content="{DynamicResource FileNamePattern}" Margin="5"  />
                         <TextBox x:Name="FileNamePattenTextBox" TextChanged="FileNamePattenTextBox_TextChanged" Margin="5" HorizontalAlignment="Left" MinWidth="120" />
-                        <Controls:Tile Grid.Row="4" Grid.Column="2" Height="30" Width="100" Click="RestPatternToDefault_Click" HorizontalAlignment="Left" >
+                        <Controls:Tile Grid.Row="4" Grid.Column="2" Height="30" MinWidth="100" Width="Auto" HorizontalAlignment="Center" Click="RestPatternToDefault_Click">
                             <Label Content="{DynamicResource ResetToDefault}" />
                         </Controls:Tile>
                     </StackPanel>

--- a/YoutubePlaylistDownloader/DownloadUpdate.xaml
+++ b/YoutubePlaylistDownloader/DownloadUpdate.xaml
@@ -17,10 +17,10 @@
             <Controls:Tile Click="Exit_Click" x:Name="UpdateNowButton" Visibility="Collapsed" HorizontalAlignment="Center" Title="{DynamicResource UpdateAndExit}" Margin="5" Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2" Controls:ControlsHelper.MouseOverBorderBrush="{DynamicResource BlackBrush}"  HorizontalTitleAlignment="Right" Style="{StaticResource LargeTileStyle}">
                 <iconPacks:PackIconModern Width="40" Height="40" Kind="CabinetIn" />
             </Controls:Tile>
-            <Controls:Tile Click="Exit_Click" x:Name="BackButton" HorizontalAlignment="Center" Title="{DynamicResource Back}" Margin="5" Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2" Controls:ControlsHelper.MouseOverBorderBrush="{DynamicResource BlackBrush}"  HorizontalTitleAlignment="Right" Style="{StaticResource LargeTileStyle}">
+            <Controls:Tile Click="Exit_Click" x:Name="BackButton" HorizontalAlignment="Center" Title="{DynamicResource Back}" Margin="5" Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2" Controls:ControlsHelper.MouseOverBorderBrush="{DynamicResource BlackBrush}" MinWidth="200" Width="Auto" HorizontalTitleAlignment="Center" Style="{StaticResource LargeTileStyle}">
                 <iconPacks:PackIconModern Width="40" Height="40" Kind="ArrowLeft" />
             </Controls:Tile>
-            <Controls:Tile Click="ExitLater_Click" x:Name="UpdateLaterButton" Visibility="Visible" HorizontalAlignment="Center" Title="{DynamicResource UpdateWhenIExit}" Margin="5" Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2" Controls:ControlsHelper.MouseOverBorderBrush="{DynamicResource BlackBrush}"  HorizontalTitleAlignment="Right" Style="{StaticResource LargeTileStyle}">
+            <Controls:Tile Click="ExitLater_Click" x:Name="UpdateLaterButton" Visibility="Visible" HorizontalAlignment="Center" Title="{DynamicResource UpdateWhenIExit}" Margin="5" Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2" Controls:ControlsHelper.MouseOverBorderBrush="{DynamicResource BlackBrush}" MinWidth="200" Width="Auto" HorizontalTitleAlignment="Center" Style="{StaticResource LargeTileStyle}">
                 <iconPacks:PackIconModern Width="40" Height="40" Kind="ClipboardVariantEdit" />
             </Controls:Tile>
         </StackPanel>

--- a/YoutubePlaylistDownloader/MainPage.xaml
+++ b/YoutubePlaylistDownloader/MainPage.xaml
@@ -76,10 +76,10 @@
 
                             </Grid>
                             <WrapPanel Grid.Row="1" HorizontalAlignment="Center">
-                                <Controls:Tile Style="{DynamicResource SmallTileStyle}" x:Name="DownloadButton" Title="{DynamicResource Download}" IsEnabled="False" Click="DownloadButton_Click">
+                                <Controls:Tile Style="{DynamicResource SmallTileStyle}" x:Name="DownloadButton" Title="{DynamicResource Download}" IsEnabled="False" MinWidth="200" Width="Auto" HorizontalTitleAlignment="Center" Click="DownloadButton_Click">
                                     <iconPacks:PackIconModern Width="40" Height="40" Kind="ArrowDown" />
                                 </Controls:Tile>
-                                <Controls:Tile Style="{DynamicResource SmallTileStyle}" x:Name="DownloadInBackgroundButton" Title="{DynamicResource DownloadInBackground}" IsEnabled="False" Click="DownloadInBackgroundButton_Click">
+                                <Controls:Tile Style="{DynamicResource SmallTileStyle}" x:Name="DownloadInBackgroundButton" Title="{DynamicResource DownloadInBackground}" MinWidth="200" Width="Auto" HorizontalTitleAlignment="Center" IsEnabled="False" Click="DownloadInBackgroundButton_Click">
                                     <iconPacks:PackIconModern Width="40" Height="40" Kind="Reset" />
                                 </Controls:Tile>
                             </WrapPanel>
@@ -107,7 +107,7 @@
                         <TextBox x:Name="BulkLinksTextBox" AcceptsReturn="True" TextWrapping="Wrap" HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto" TextChanged="TextBox_TextChanged_1" FontSize="16" PreviewDrop="BulkLinksTextBox_PreviewDrop"  />
                     </ScrollViewer>
                     <WrapPanel Grid.Row="1" HorizontalAlignment="Center">
-                        <Controls:Tile Style="{DynamicResource SmallTileStyle}" x:Name="BulkDownloadButton" Title="{DynamicResource Download}" IsEnabled="False" Click="BulkDownloadButton_Click">
+                        <Controls:Tile Style="{DynamicResource SmallTileStyle}" x:Name="BulkDownloadButton" Title="{DynamicResource Download}" MinWidth="200" Width="Auto" HorizontalTitleAlignment="Center" IsEnabled="False" Click="BulkDownloadButton_Click">
                             <iconPacks:PackIconModern Width="40" Height="40" Kind="ArrowDown" />
                         </Controls:Tile>
                     </WrapPanel>

--- a/YoutubePlaylistDownloader/Settings.xaml
+++ b/YoutubePlaylistDownloader/Settings.xaml
@@ -64,7 +64,7 @@
 
             </Controls:MetroTabItem>
         </Controls:MetroAnimatedTabControl>
-        <Controls:Tile Click="Exit_Click" HorizontalAlignment="Center" Title="{DynamicResource SaveAndBackToDownload}" Margin="5" Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2" Controls:ControlsHelper.MouseOverBorderBrush="{DynamicResource BlackBrush}"  HorizontalTitleAlignment="Right" Style="{StaticResource LargeTileStyle}">
+        <Controls:Tile Click="Exit_Click" HorizontalAlignment="Center" Title="{DynamicResource SaveAndBackToDownload}" Margin="5" Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2" MinWidth="200" Width="Auto" HorizontalTitleAlignment="Center" Controls:ControlsHelper.MouseOverBorderBrush="{DynamicResource BlackBrush}" Style="{StaticResource LargeTileStyle}">
             <iconPacks:PackIconModern Width="40" Height="40" Kind="ArrowLeft" />
         </Controls:Tile>
     </StackPanel>


### PR DESCRIPTION
Improved UI when using a language other than English:

 - added MinWidth and set Width to Auto for all buttons;
 - set HorizontalTitleAlignment to Centered for all buttons for consistent look and feel across languages.
 
 
When I added the Romanian language I noticed that the buttons were either too small to accommodate the text or the text was overlapping with the icons. Few screenshots (before and after):

_Before_
![image](https://github.com/user-attachments/assets/a88b092c-db4b-4d31-bf94-c1fe0357123b)

_After_
![image](https://github.com/user-attachments/assets/c7c11b74-6e92-474d-a458-c656f518db18)

_Before_
![image](https://github.com/user-attachments/assets/de9d19cb-0244-4768-96df-ab53d92ce048)

_After_
![image](https://github.com/user-attachments/assets/3f329e26-ea90-4381-b7aa-f864bd0b81f7)

_Before_
![image](https://github.com/user-attachments/assets/b89cf62d-cfbc-496c-81db-61050bdb4aa2)

_After_
![image](https://github.com/user-attachments/assets/f04aafdd-aa40-4e05-b3da-62e4518f33b8)

_Before_
![image](https://github.com/user-attachments/assets/c9221324-7291-4840-9c2a-7be260f458f5)

_After_
![image](https://github.com/user-attachments/assets/095c459b-148c-4a3d-9942-e9cbd66999b5)

P.S. This is the last PR for a while, unless I find a bug or something.