### PR TITLE
FFmpeg / build improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -297,7 +297,3 @@ __pycache__/
 *.btm.cs
 *.odx.cs
 *.xsd.cs
-
-YoutubePlaylistDownloader/ffmpeg.exe
-/Installer Output/
-/FFmpeg/

--- a/FFmpeg/.gitignore
+++ b/FFmpeg/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except for this file
+!.gitignore

--- a/InstallerOutput/.gitignore
+++ b/InstallerOutput/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except for this file
+!.gitignore

--- a/YPDSetup/YPDSetup.iss
+++ b/YPDSetup/YPDSetup.iss
@@ -16,7 +16,7 @@ AppUpdatesURL=https://github.com/shaked6540/YoutubePlaylistDownloader
 DefaultDirName={commonpf}\YouTube Playlist Downloader
 DefaultGroupName=YouTube Playlist Downloader
 AllowNoIcons=yes
-OutputDir=D:\Inno output\1.9.33
+OutputDir=..\InstallerOutput\1.9.33\
 OutputBaseFilename=YoutubePlaylistDownloader
 SetupIconFile=..\YoutubePlaylistDownloader\finalIcon.ico
 Compression=lzma
@@ -33,7 +33,6 @@ Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{
 
 [Files]
 Source: "..\YoutubePlaylistDownloader\bin\Release\net8.0-windows\*"; DestDir: "{app}"; Flags: ignoreversion
-Source: "C:\bin\bin32\ffmpeg.exe"; DestDir: "{app}"; Flags: ignoreversion
 
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files        
 

--- a/YoutubePlaylistDownloader/YoutubePlaylistDownloader.csproj
+++ b/YoutubePlaylistDownloader/YoutubePlaylistDownloader.csproj
@@ -88,4 +88,7 @@
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>
     </None>
   </ItemGroup>
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="xcopy /Y /d &quot;$(SolutionDir)FFmpeg\ffmpeg.exe&quot; &quot;$(ProjectDir)bin\$(Configuration)\$(TargetFramework)\&quot;" />
+  </Target>
 </Project>


### PR DESCRIPTION
 - added PostBuild target to copy ffmpeg.exe to the build folder;
 - updated the installer file to remove ffmpeg.exe as it is picked from the build folder instead;
 - both InstallerOutput and FFmpeg folders are now created on git checkout, but their content is ignored by the source control.
 
This completes the work done in https://github.com/shaked6540/YoutubePlaylistDownloader/pull/266.
 
Now there is a single source for ffmpeg.exe, both for the installer and for when you run the app from VS. Also, you don't have to manually copy ffmpeg.exe into the build folder anymore.