### PR TITLE
Harden download pipeline and add Windows CI coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,3 +21,5 @@ jobs:
         run: dotnet restore YoutubePlaylistDownloader.sln
       - name: Build
         run: dotnet build YoutubePlaylistDownloader.sln --configuration Release --no-restore
+      - name: Test
+        run: dotnet test YoutubePlaylistDownloader.sln --configuration Release --no-build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+      - name: Restore
+        run: dotnet restore YoutubePlaylistDownloader.sln
+      - name: Build
+        run: dotnet build YoutubePlaylistDownloader.sln --configuration Release --no-restore

--- a/README.md
+++ b/README.md
@@ -7,6 +7,18 @@
 ## What is it?
 A simple program to download whole playlists\channels or even single videos from YouTube 
 
+## Building locally
+
+The application targets Windows and .NET 8 because it uses WPF. Install Visual Studio 2022 with the Desktop development with .NET workload, then run:
+
+```powershell
+dotnet restore YoutubePlaylistDownloader.sln
+dotnet build YoutubePlaylistDownloader.sln -c Debug
+dotnet run --project YoutubePlaylistDownloader/YoutubePlaylistDownloader.csproj
+```
+
+For video downloads and conversions, place `ffmpeg.exe` beside the generated executable in `YoutubePlaylistDownloader\\bin\\Debug\\net8.0-windows\\`.
+
 [Click here to download the installer](https://github.com/shaked6540/YoutubePlaylistDownloader/releases/download/1.9.34/YoutubePlaylistDownloader.exe) 
 
 ## Features

--- a/YoutubePlaylistDownloader.Tests/AtomicFileTests.cs
+++ b/YoutubePlaylistDownloader.Tests/AtomicFileTests.cs
@@ -1,0 +1,39 @@
+using YoutubePlaylistDownloader.Utilities;
+using Xunit;
+
+namespace YoutubePlaylistDownloader.Tests;
+
+public class AtomicFileTests : IDisposable
+{
+    private readonly string directory = Path.Combine(Path.GetTempPath(), "ypd-tests-" + Guid.NewGuid());
+
+    public AtomicFileTests() => Directory.CreateDirectory(directory);
+
+    [Fact]
+    public void CopyAndReplace_writes_complete_destination_and_removes_partial_file()
+    {
+        var source = Path.Combine(directory, "source.bin");
+        var destination = Path.Combine(directory, "destination.bin");
+        File.WriteAllText(source, "complete content");
+
+        AtomicFile.CopyAndReplace(source, destination);
+
+        Assert.Equal("complete content", File.ReadAllText(destination));
+        Assert.False(File.Exists(destination + ".part"));
+    }
+
+    [Fact]
+    public void CopyAndReplace_preserves_existing_destination_when_source_is_missing()
+    {
+        var source = Path.Combine(directory, "missing.bin");
+        var destination = Path.Combine(directory, "destination.bin");
+        File.WriteAllText(destination, "existing content");
+
+        Assert.Throws<FileNotFoundException>(() => AtomicFile.CopyAndReplace(source, destination));
+
+        Assert.Equal("existing content", File.ReadAllText(destination));
+        Assert.False(File.Exists(destination + ".part"));
+    }
+
+    public void Dispose() => Directory.Delete(directory, true);
+}

--- a/YoutubePlaylistDownloader.Tests/AtomicFileTests.cs
+++ b/YoutubePlaylistDownloader.Tests/AtomicFileTests.cs
@@ -35,5 +35,17 @@ public class AtomicFileTests : IDisposable
         Assert.False(File.Exists(destination + ".part"));
     }
 
+    [Fact]
+    public void WriteAllText_replaces_destination_without_leaving_partial_file()
+    {
+        var destination = Path.Combine(directory, "settings.json");
+        File.WriteAllText(destination, "old");
+
+        AtomicFile.WriteAllText(destination, "new");
+
+        Assert.Equal("new", File.ReadAllText(destination));
+        Assert.False(File.Exists(destination + ".part"));
+    }
+
     public void Dispose() => Directory.Delete(directory, true);
 }

--- a/YoutubePlaylistDownloader.Tests/DownloadPathsTests.cs
+++ b/YoutubePlaylistDownloader.Tests/DownloadPathsTests.cs
@@ -1,0 +1,20 @@
+using YoutubePlaylistDownloader.Utilities;
+using Xunit;
+
+namespace YoutubePlaylistDownloader.Tests;
+
+public class DownloadPathsTests
+{
+    [Fact]
+    public void Create_uses_part_files_for_all_intermediates()
+    {
+        var paths = DownloadPaths.Create("C:\\Temp\\", "video-id", "mp4", "m4a")
+            .WithDestination("C:\\Downloads\\video.mp4");
+
+        Assert.Equal("C:\\Temp\\video-id.part", paths.Input);
+        Assert.Equal("C:\\Temp\\video-id.part.mp4", paths.Output);
+        Assert.Equal("C:\\Temp\\video-id-audio.m4a.part", paths.Audio);
+        Assert.Equal("C:\\Temp\\video-id.srt.part", paths.Captions);
+        Assert.Equal("C:\\Downloads\\video.mp4", paths.Destination);
+    }
+}

--- a/YoutubePlaylistDownloader.Tests/YoutubePlaylistDownloader.Tests.csproj
+++ b/YoutubePlaylistDownloader.Tests/YoutubePlaylistDownloader.Tests.csproj
@@ -12,5 +12,6 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\YoutubePlaylistDownloader\Utilities\AtomicFile.cs" Link="AtomicFile.cs" />
+    <Compile Include="..\YoutubePlaylistDownloader\Utilities\DownloadPaths.cs" Link="DownloadPaths.cs" />
   </ItemGroup>
 </Project>

--- a/YoutubePlaylistDownloader.Tests/YoutubePlaylistDownloader.Tests.csproj
+++ b/YoutubePlaylistDownloader.Tests/YoutubePlaylistDownloader.Tests.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\YoutubePlaylistDownloader\Utilities\AtomicFile.cs" Link="AtomicFile.cs" />
+  </ItemGroup>
+</Project>

--- a/YoutubePlaylistDownloader.sln
+++ b/YoutubePlaylistDownloader.sln
@@ -4,6 +4,8 @@ VisualStudioVersion = 17.4.33403.182
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "YoutubePlaylistDownloader", "YoutubePlaylistDownloader\YoutubePlaylistDownloader.csproj", "{57ADF475-AC13-4912-A26B-100C6535A74D}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "YoutubePlaylistDownloader.Tests", "YoutubePlaylistDownloader.Tests\YoutubePlaylistDownloader.Tests.csproj", "{A7D3F4D1-7D70-4A76-94C0-1D5D3FD95D3C}"
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{2A76AF85-987A-41AE-8D9B-5A510CFB2455}"
 	ProjectSection(SolutionItems) = preProject
 		LICENSE = LICENSE
@@ -21,6 +23,10 @@ Global
 		{57ADF475-AC13-4912-A26B-100C6535A74D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{57ADF475-AC13-4912-A26B-100C6535A74D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{57ADF475-AC13-4912-A26B-100C6535A74D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A7D3F4D1-7D70-4A76-94C0-1D5D3FD95D3C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A7D3F4D1-7D70-4A76-94C0-1D5D3FD95D3C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A7D3F4D1-7D70-4A76-94C0-1D5D3FD95D3C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A7D3F4D1-7D70-4A76-94C0-1D5D3FD95D3C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/YoutubePlaylistDownloader/DownloadPage.xaml.cs
+++ b/YoutubePlaylistDownloader/DownloadPage.xaml.cs
@@ -330,12 +330,12 @@ public partial class DownloadPage : UserControl, IDisposable, IDownload
                     }
                     var cleanFileNameWithID = GlobalConsts.CleanFileName(video.Title + video.Id);
                     var cleanFileName = GlobalConsts.CleanFileName(downloadSettings.GetFilenameByPattern(video, i, title, Playlist));
-                    var fileLoc = $"{GlobalConsts.TempFolderPath}{cleanFileNameWithID}";
+                    var fileLoc = $"{GlobalConsts.TempFolderPath}{cleanFileNameWithID}.part";
 
                     if (AudioOnly)
                         FileType = bestQuality.Container.Name;
 
-                    var outputFileLoc = $"{GlobalConsts.TempFolderPath}{cleanFileNameWithID}.{FileType}";
+                    var outputFileLoc = $"{GlobalConsts.TempFolderPath}{cleanFileNameWithID}.part.{FileType}";
                     var copyFileLoc = $"{SavePath}\\{cleanFileName}.{FileType}";
 
                     if (GlobalConsts.DownloadSettings.SkipExisting && File.Exists(copyFileLoc))
@@ -462,7 +462,7 @@ public partial class DownloadPage : UserControl, IDisposable, IDownload
                                 var copyFileLocCounter = 1;
                                 while (File.Exists(copyFileLoc))
                                     copyFileLoc = $"{SavePath}\\{cleanFileName}-{copyFileLocCounter++}.{FileType}";
-                                File.Copy(outputFileLoc, copyFileLoc, true);
+                                AtomicFile.CopyAndReplace(outputFileLoc, copyFileLoc);
                                 File.Delete(outputFileLoc);
                             }
                             catch (Exception ex)
@@ -473,13 +473,15 @@ public partial class DownloadPage : UserControl, IDisposable, IDownload
                             {
                                 if (lockTaken) GlobalConsts.ConversionsLocker.Release();
                                 convertingCount--;
+                                File.Delete(fileLoc);
+                                File.Delete(outputFileLoc);
                             }
                         }
                         conversionTasks.Add(ConvertAsync());
                     }
                     else
                     {
-                        File.Copy(fileLoc, copyFileLoc, true);
+                        AtomicFile.CopyAndReplace(fileLoc, copyFileLoc);
 
                         File.Delete(fileLoc);
                         try
@@ -665,11 +667,11 @@ public partial class DownloadPage : UserControl, IDisposable, IDownload
                 }
                 var cleanVideoNameWithId = GlobalConsts.CleanFileName(video.Title + video.Id);
                 var cleanVideoName = GlobalConsts.CleanFileName(downloadSettings.GetFilenameByPattern(video, i, title, Playlist));
-                var fileLoc = $"{GlobalConsts.TempFolderPath}{cleanVideoNameWithId}";
-                var outputFileLoc = $"{GlobalConsts.TempFolderPath}{cleanVideoNameWithId}.{VideoSaveFormat}";
+                var fileLoc = $"{GlobalConsts.TempFolderPath}{cleanVideoNameWithId}.part";
+                var outputFileLoc = $"{GlobalConsts.TempFolderPath}{cleanVideoNameWithId}.part.{VideoSaveFormat}";
                 var copyFileLoc = $"{SavePath}\\{cleanVideoName}.{VideoSaveFormat}";
-                var audioLoc = $"{GlobalConsts.TempFolderPath}{cleanVideoNameWithId}-audio.{bestAudio.Container.Name}";
-                var captionsLoc = $"{GlobalConsts.TempFolderPath}{cleanVideoNameWithId}.srt";
+                var audioLoc = $"{GlobalConsts.TempFolderPath}{cleanVideoNameWithId}-audio.{bestAudio.Container.Name}.part";
+                var captionsLoc = $"{GlobalConsts.TempFolderPath}{cleanVideoNameWithId}.srt.part";
 
                 if (GlobalConsts.DownloadSettings.SkipExisting && File.Exists(copyFileLoc))
                 {
@@ -774,7 +776,7 @@ public partial class DownloadPage : UserControl, IDisposable, IDownload
                             if (VideoSaveFormat != "mkv")
                             {
                                 ffmpegArguments = $"-i \"{fileLoc}\" -i \"{audioLoc}\" -y -c copy \"{outputFileLoc}\"";
-                                File.Copy(captionsLoc, $"{SavePath}\\{cleanVideoName}.srt");
+                                AtomicFile.CopyAndReplace(captionsLoc, $"{SavePath}\\{cleanVideoName}.srt");
                             }
                             else
                             {
@@ -831,6 +833,10 @@ public partial class DownloadPage : UserControl, IDisposable, IDownload
                     {
                         if (lockTaken) GlobalConsts.ConversionsLocker.Release();
                         convertingCount--;
+                        File.Delete(fileLoc);
+                        File.Delete(outputFileLoc);
+                        File.Delete(audioLoc);
+                        File.Delete(captionsLoc);
                     }
                 }
                 conversionTasks.Add(ConvertAsync());

--- a/YoutubePlaylistDownloader/DownloadPage.xaml.cs
+++ b/YoutubePlaylistDownloader/DownloadPage.xaml.cs
@@ -361,6 +361,7 @@ public partial class DownloadPage : UserControl, IDisposable, IDownload
                         Stopwatch sw = new();
                         TimeSpan ts = new(0);
                         var seconds = 1;
+                        var lastProgressUpdate = TimeSpan.MinValue;
                         var downloadSpeedText = (string)FindResource("DownloadSpeed");
 
                         stream.BytesWritten += async (sender, args) =>
@@ -385,6 +386,10 @@ public partial class DownloadPage : UserControl, IDisposable, IDownload
 
                                 if (!sw.IsRunning)
                                     sw.Start();
+
+                                if (percent < 100 && sw.Elapsed - lastProgressUpdate < TimeSpan.FromMilliseconds(100))
+                                    return;
+                                lastProgressUpdate = sw.Elapsed;
 
                                 await Dispatcher.InvokeAsync(() =>
                                 {
@@ -698,6 +703,7 @@ public partial class DownloadPage : UserControl, IDisposable, IDownload
                     Stopwatch sw = new();
                     TimeSpan ts = new(0);
                     var seconds = 1;
+                    var lastProgressUpdate = TimeSpan.MinValue;
                     var downloadSpeedText = (string)FindResource("DownloadSpeed");
 
                     stream.BytesWritten += async (sender, args) =>
@@ -721,6 +727,10 @@ public partial class DownloadPage : UserControl, IDisposable, IDownload
                             }
                             if (!sw.IsRunning)
                                 sw.Start();
+
+                            if (percent < 100 && sw.Elapsed - lastProgressUpdate < TimeSpan.FromMilliseconds(100))
+                                return;
+                            lastProgressUpdate = sw.Elapsed;
 
                             await Dispatcher.InvokeAsync(() =>
                             {

--- a/YoutubePlaylistDownloader/DownloadPage.xaml.cs
+++ b/YoutubePlaylistDownloader/DownloadPage.xaml.cs
@@ -122,8 +122,9 @@ public partial class DownloadPage : UserControl, IDisposable, IDownload
                 Videos.Where(video => video.Duration.Value.TotalMinutes < settings.FilterByLengthValue);
         }
 
-        var startIndex = settings.SubsetStartIndex <= 0 ? 0 : settings.SubsetStartIndex;
-        var endIndex = settings.SubsetEndIndex <= 0 ? Videos.Count() - 1 : settings.SubsetEndIndex;
+        var videoCount = Videos.Count();
+        var startIndex = videoCount == 0 ? 0 : Math.Clamp(settings.SubsetStartIndex, 0, videoCount - 1);
+        var endIndex = videoCount == 0 ? -1 : Math.Clamp(settings.SubsetEndIndex <= 0 ? videoCount - 1 : settings.SubsetEndIndex, startIndex, videoCount - 1);
 
         this.silent = silent;
 
@@ -143,29 +144,28 @@ public partial class DownloadPage : UserControl, IDisposable, IDownload
         Maximum = EndIndex - StartIndex + 1;
         DownloadedVideosProgressBar.Maximum = Maximum;
         Playlist = playlist;
-        FileType = settings.SaveFormat;
-        VideoSaveFormat = settings.VideoSaveFormat;
+        FileType = DownloadSettings.AudioFormats.Contains(settings.SaveFormat?.ToLowerInvariant()) ? settings.SaveFormat.ToLowerInvariant() : "mp3";
+        VideoSaveFormat = DownloadSettings.VideoFormats.Contains(settings.VideoSaveFormat?.ToLowerInvariant()) ? settings.VideoSaveFormat.ToLowerInvariant() : "mkv";
         DownloadedCount = 0;
         Quality = settings.Quality;
         DownloadCaptions = settings.DownloadCaptions;
         CaptionsLanguage = settings.CaptionsLanguage;
-        SavePath = string.IsNullOrWhiteSpace(savePath) ? GlobalConsts.settings.SaveDirectory : savePath;
+        var resolvedSavePath = string.IsNullOrWhiteSpace(savePath) ? GlobalConsts.settings.SaveDirectory : savePath;
 
         if (settings.SavePlaylistsInDifferentDirectories && playlist != null)
         {
             if (!string.IsNullOrWhiteSpace(playlist.Title))
             {
-                SavePath += $"\\{GlobalConsts.CleanFileName(playlist.Title)}";
+                resolvedSavePath += $"\\{GlobalConsts.CleanFileName(playlist.Title)}";
             }
             else if (!string.IsNullOrWhiteSpace(playlist.BasePlaylist?.Title))
             {
-                SavePath += $"\\{GlobalConsts.CleanFileName(playlist?.BasePlaylist?.Title)}";
+                resolvedSavePath += $"\\{GlobalConsts.CleanFileName(playlist?.BasePlaylist?.Title)}";
             }
 
         }
 
-        if (!Directory.Exists(SavePath))
-            Directory.CreateDirectory(SavePath);
+        SavePath = EnsureSaveDirectory(resolvedSavePath);
 
         AudioOnly = settings.AudioOnly;
         TagAudioFile = settings.TagAudioFile;
@@ -190,6 +190,26 @@ public partial class DownloadPage : UserControl, IDisposable, IDownload
             StartDownloading(cts.Token).ConfigureAwait(false);
 
         GlobalConsts.Downloads.Add(new QueuedDownload(this));
+    }
+
+    private static string EnsureSaveDirectory(string path)
+    {
+        var fallback = Environment.GetFolderPath(Environment.SpecialFolder.MyVideos);
+        foreach (var candidate in new[] { path, fallback, GlobalConsts.TempFolderPath })
+        {
+            try
+            {
+                if (!string.IsNullOrWhiteSpace(candidate))
+                    Directory.CreateDirectory(candidate);
+                if (Directory.Exists(candidate))
+                    return candidate;
+            }
+            catch (Exception ex) when (ex is ArgumentException or IOException or UnauthorizedAccessException or NotSupportedException)
+            {
+            }
+        }
+
+        throw new IOException("Unable to create a usable download directory.");
     }
 
     public static async Task SequenceDownload(IEnumerable<string> links, DownloadSettings settings, bool silent = false)
@@ -369,7 +389,6 @@ public partial class DownloadPage : UserControl, IDisposable, IDownload
                             try
                             {
                                 var percent = Convert.ToInt32(args.StreamLength * 100 / bestQuality.Size.Bytes);
-                                CurrentProgressPercent = percent;
                                 double speedInMB = 0;
                                 var delta = sw.Elapsed - ts;
                                 ts = sw.Elapsed;
@@ -390,6 +409,7 @@ public partial class DownloadPage : UserControl, IDisposable, IDownload
                                 if (percent < 100 && sw.Elapsed - lastProgressUpdate < TimeSpan.FromMilliseconds(100))
                                     return;
                                 lastProgressUpdate = sw.Elapsed;
+                                CurrentProgressPercent = percent;
 
                                 await Dispatcher.InvokeAsync(() =>
                                 {
@@ -711,7 +731,6 @@ public partial class DownloadPage : UserControl, IDisposable, IDownload
                         try
                         {
                             var percent = Convert.ToInt32(args.StreamLength * 100 / bestQuality.Size.Bytes);
-                            CurrentProgressPercent = percent;
                             double speedInMB = 0;
                             var delta = sw.Elapsed - ts;
                             ts = sw.Elapsed;
@@ -731,6 +750,7 @@ public partial class DownloadPage : UserControl, IDisposable, IDownload
                             if (percent < 100 && sw.Elapsed - lastProgressUpdate < TimeSpan.FromMilliseconds(100))
                                 return;
                             lastProgressUpdate = sw.Elapsed;
+                            CurrentProgressPercent = percent;
 
                             await Dispatcher.InvokeAsync(() =>
                             {

--- a/YoutubePlaylistDownloader/DownloadPage.xaml.cs
+++ b/YoutubePlaylistDownloader/DownloadPage.xaml.cs
@@ -350,13 +350,14 @@ public partial class DownloadPage : UserControl, IDisposable, IDownload
                     }
                     var cleanFileNameWithID = GlobalConsts.CleanFileName(video.Title + video.Id);
                     var cleanFileName = GlobalConsts.CleanFileName(downloadSettings.GetFilenameByPattern(video, i, title, Playlist));
-                    var fileLoc = $"{GlobalConsts.TempFolderPath}{cleanFileNameWithID}.part";
-
                     if (AudioOnly)
                         FileType = bestQuality.Container.Name;
 
-                    var outputFileLoc = $"{GlobalConsts.TempFolderPath}{cleanFileNameWithID}.part.{FileType}";
-                    var copyFileLoc = $"{SavePath}\\{cleanFileName}.{FileType}";
+                    var paths = DownloadPaths.Create(GlobalConsts.TempFolderPath, cleanFileNameWithID, FileType)
+                        .WithDestination($"{SavePath}\\{cleanFileName}.{FileType}");
+                    var fileLoc = paths.Input;
+                    var outputFileLoc = paths.Output;
+                    var copyFileLoc = paths.Destination;
 
                     if (GlobalConsts.DownloadSettings.SkipExisting && File.Exists(copyFileLoc))
                     {
@@ -692,11 +693,13 @@ public partial class DownloadPage : UserControl, IDisposable, IDownload
                 }
                 var cleanVideoNameWithId = GlobalConsts.CleanFileName(video.Title + video.Id);
                 var cleanVideoName = GlobalConsts.CleanFileName(downloadSettings.GetFilenameByPattern(video, i, title, Playlist));
-                var fileLoc = $"{GlobalConsts.TempFolderPath}{cleanVideoNameWithId}.part";
-                var outputFileLoc = $"{GlobalConsts.TempFolderPath}{cleanVideoNameWithId}.part.{VideoSaveFormat}";
-                var copyFileLoc = $"{SavePath}\\{cleanVideoName}.{VideoSaveFormat}";
-                var audioLoc = $"{GlobalConsts.TempFolderPath}{cleanVideoNameWithId}-audio.{bestAudio.Container.Name}.part";
-                var captionsLoc = $"{GlobalConsts.TempFolderPath}{cleanVideoNameWithId}.srt.part";
+                var paths = DownloadPaths.Create(GlobalConsts.TempFolderPath, cleanVideoNameWithId, VideoSaveFormat, bestAudio.Container.Name)
+                    .WithDestination($"{SavePath}\\{cleanVideoName}.{VideoSaveFormat}");
+                var fileLoc = paths.Input;
+                var outputFileLoc = paths.Output;
+                var copyFileLoc = paths.Destination;
+                var audioLoc = paths.Audio;
+                var captionsLoc = paths.Captions;
 
                 if (GlobalConsts.DownloadSettings.SkipExisting && File.Exists(copyFileLoc))
                 {

--- a/YoutubePlaylistDownloader/DownloadPage.xaml.cs
+++ b/YoutubePlaylistDownloader/DownloadPage.xaml.cs
@@ -434,13 +434,18 @@ public partial class DownloadPage : UserControl, IDisposable, IDownload
                         };
 
                         token.ThrowIfCancellationRequested();
-                        ffmpeg.Exited += async (x, y) =>
+                        async Task ConvertAsync()
                         {
+                            var lockTaken = false;
                             try
                             {
-                                ffmpegList?.Remove(ffmpeg);
-                                convertingCount--;
-
+                                if (GlobalConsts.settings.LimitConversions)
+                                {
+                                    await GlobalConsts.ConversionsLocker.WaitAsync(token);
+                                    lockTaken = true;
+                                }
+                                convertingCount++;
+                                await RunFfmpegAsync(ffmpeg, outputFileLoc, token);
                                 if (TagAudioFile)
                                 {
                                     var videoIndex = indexes[video];
@@ -449,57 +454,28 @@ public partial class DownloadPage : UserControl, IDisposable, IDownload
                                     if (afterTagName != outputFileLoc)
                                     {
                                         if (playlistId.HasValue)
-                                        {
                                             video = new PlaylistVideo(playlistId.Value, video.Id, afterTagName, video.Author, video.Duration, video.Thumbnails);
-                                        }
-
                                         cleanFileName = GlobalConsts.CleanFileName(downloadSettings.GetFilenameByPattern(video, videoIndex - 1, title, Playlist));
                                         copyFileLoc = $"{SavePath}\\{cleanFileName}.{FileType}";
                                     }
                                 }
                                 var copyFileLocCounter = 1;
                                 while (File.Exists(copyFileLoc))
-                                {
-                                    copyFileLoc = $"{SavePath}\\{cleanFileName}-{copyFileLocCounter}.{FileType}";
-                                    copyFileLocCounter++;
-                                }
+                                    copyFileLoc = $"{SavePath}\\{cleanFileName}-{copyFileLocCounter++}.{FileType}";
                                 File.Copy(outputFileLoc, copyFileLoc, true);
                                 File.Delete(outputFileLoc);
-
                             }
                             catch (Exception ex)
                             {
                                 await GlobalConsts.Log(ex.ToString(), "DownloadPage with convert");
                             }
-                        };
-                        if (!GlobalConsts.settings.LimitConversions)
-                        {
-                            ffmpeg.Start();
-                            convertingCount++;
-                            ffmpegList.Add(ffmpeg);
-                        }
-                        else
-                        {
-                            conversionTasks.Add(Task.Run(async () =>
+                            finally
                             {
-                                try
-                                {
-                                    convertingCount++;
-                                    await GlobalConsts.ConversionsLocker.WaitAsync(cts.Token);
-                                    ffmpeg.Start();
-                                    ffmpeg.Exited += (x, y) => GlobalConsts.ConversionsLocker.Release();
-                                    ffmpegList.Add(ffmpeg);
-                                }
-                                catch (OperationCanceledException)
-                                {
-                                    GlobalConsts.ConversionsLocker.Release();
-                                }
-                                catch (Exception ex)
-                                {
-                                    await GlobalConsts.Log(ex.ToString(), "ConversionsLocker at StartDownloadingWithConverting at DownloadPage.xaml.cs");
-                                }
-                            }, token));
+                                if (lockTaken) GlobalConsts.ConversionsLocker.Release();
+                                convertingCount--;
+                            }
                         }
+                        conversionTasks.Add(ConvertAsync());
                     }
                     else
                     {
@@ -827,20 +803,22 @@ public partial class DownloadPage : UserControl, IDisposable, IDownload
                 };
 
                 token.ThrowIfCancellationRequested();
-                ffmpeg.Exited += async (x, y) =>
+                async Task ConvertAsync()
                 {
+                    var lockTaken = false;
                     try
                     {
-                        ffmpegList?.Remove(ffmpeg);
-                        convertingCount--;
+                        if (GlobalConsts.settings.LimitConversions)
+                        {
+                            await GlobalConsts.ConversionsLocker.WaitAsync(token);
+                            lockTaken = true;
+                        }
+                        convertingCount++;
+                        await RunFfmpegAsync(ffmpeg, outputFileLoc, token);
                         var copyFileLocCounter = 1;
                         while (File.Exists(copyFileLoc))
-                        {
-                            copyFileLoc = $"{SavePath}\\{cleanVideoName}-{copyFileLocCounter}.{VideoSaveFormat}";
-                            copyFileLocCounter++;
-                        }
+                            copyFileLoc = $"{SavePath}\\{cleanVideoName}-{copyFileLocCounter++}.{VideoSaveFormat}";
                         File.Copy(outputFileLoc, copyFileLoc, true);
-
                         File.Delete(outputFileLoc);
                         File.Delete(audioLoc);
                         File.Delete(fileLoc);
@@ -849,36 +827,13 @@ public partial class DownloadPage : UserControl, IDisposable, IDownload
                     {
                         await GlobalConsts.Log(ex.ToString(), "DownloadPage without convert");
                     }
-                };
-
-                if (!GlobalConsts.settings.LimitConversions)
-                {
-                    ffmpeg.Start();
-                    convertingCount++;
-                    ffmpegList.Add(ffmpeg);
-                }
-                else
-                {
-                    conversionTasks.Add(Task.Run(async () =>
+                    finally
                     {
-                        try
-                        {
-                            convertingCount++;
-                            await GlobalConsts.ConversionsLocker.WaitAsync(cts.Token);
-                            ffmpeg.Start();
-                            ffmpeg.Exited += (x, y) => GlobalConsts.ConversionsLocker.Release();
-                            ffmpegList.Add(ffmpeg);
-                        }
-                        catch (OperationCanceledException)
-                        {
-                            GlobalConsts.ConversionsLocker.Release();
-                        }
-                        catch (Exception ex)
-                        {
-                            await GlobalConsts.Log(ex.ToString(), "ConversionsLocker at StartDownloading at DownloadPage.xaml.cs");
-                        }
-                    }, token));
+                        if (lockTaken) GlobalConsts.ConversionsLocker.Release();
+                        convertingCount--;
+                    }
                 }
+                conversionTasks.Add(ConvertAsync());
 
                 DownloadedCount++;
                 TotalDownloaded = $"({DownloadedCount}/{Maximum})";
@@ -956,6 +911,31 @@ public partial class DownloadPage : UserControl, IDisposable, IDownload
             OpenFolder_Click(null, null);
 
         Dispose();
+    }
+
+    private async Task RunFfmpegAsync(Process ffmpeg, string outputFilePath, CancellationToken token)
+    {
+        ffmpeg.Start();
+        ffmpegList.Add(ffmpeg);
+        try
+        {
+            await ffmpeg.WaitForExitAsync(token);
+            if (ffmpeg.ExitCode != 0)
+                throw new InvalidOperationException($"FFmpeg exited with code {ffmpeg.ExitCode}.");
+            if (!File.Exists(outputFilePath))
+                throw new InvalidOperationException("FFmpeg did not create the output file.");
+        }
+        catch (OperationCanceledException)
+        {
+            if (!ffmpeg.HasExited)
+                ffmpeg.Kill();
+            throw;
+        }
+        finally
+        {
+            ffmpegList.Remove(ffmpeg);
+            ffmpeg.Dispose();
+        }
     }
 
     private void Background_Exit(object sender, RoutedEventArgs e)

--- a/YoutubePlaylistDownloader/DownloadUpdate.xaml.cs
+++ b/YoutubePlaylistDownloader/DownloadUpdate.xaml.cs
@@ -112,19 +112,56 @@ public partial class DownloadUpdate : UserControl, IDownload
 
     private async Task StartUpdate()
     {
-        await Dispatcher.InvokeAsync(() => HeadlineTextBlock.Text = $"{FindResource("DownloadingUpdateSetup")}");
-        using var fs = new ProgressStream(new FileStream(GlobalConsts.UpdateSetupLocation, FileMode.Create));
-        fs.BytesWritten += DownloadProgressChanged;
-        var latestVersionLink = await httpClient.GetAsync("https://raw.githubusercontent.com/shaked6540/YoutubePlaylistDownloader/master/YoutubePlaylistDownloader/latestVersionLink.txt").ConfigureAwait(false);
-        var response = await httpClient.GetAsync(await latestVersionLink.Content.ReadAsStringAsync().ConfigureAwait(false)).ConfigureAwait(false);
-        await Dispatcher.InvokeAsync(() => CurrentDownloadProgressBar.Maximum = response.Content.Headers.ContentLength ?? 0);
-        await response.Content.CopyToAsync(fs, cancellationTokenSource.Token).ContinueWith(async a =>
+        var updatePath = GlobalConsts.UpdateSetupLocation;
+        var partialPath = $"{updatePath}.part";
+        try
         {
+            await Dispatcher.InvokeAsync(() => HeadlineTextBlock.Text = $"{FindResource("DownloadingUpdateSetup")}");
+            var latestVersionLink = await httpClient.GetAsync("https://raw.githubusercontent.com/shaked6540/YoutubePlaylistDownloader/master/YoutubePlaylistDownloader/latestVersionLink.txt", cancellationTokenSource.Token);
+            latestVersionLink.EnsureSuccessStatusCode();
+            var downloadUrl = (await latestVersionLink.Content.ReadAsStringAsync(cancellationTokenSource.Token)).Trim();
+            if (!Uri.TryCreate(downloadUrl, UriKind.Absolute, out var uri) || uri.Scheme != Uri.UriSchemeHttps ||
+                (uri.Host != "github.com" && uri.Host != "objects.githubusercontent.com"))
+                throw new InvalidDataException("The update URL is not a trusted GitHub HTTPS URL.");
+
+            using var response = await httpClient.GetAsync(uri, HttpCompletionOption.ResponseHeadersRead, cancellationTokenSource.Token);
+            response.EnsureSuccessStatusCode();
+            await Dispatcher.InvokeAsync(() => CurrentDownloadProgressBar.Maximum = response.Content.Headers.ContentLength ?? 0);
+
+            await using (var file = new ProgressStream(new FileStream(partialPath, FileMode.Create, FileAccess.Write, FileShare.None)))
+            {
+                file.BytesWritten += DownloadProgressChanged;
+                await response.Content.CopyToAsync(file, cancellationTokenSource.Token);
+            }
+
+            if (!File.Exists(partialPath) || new FileInfo(partialPath).Length == 0)
+                throw new InvalidDataException("The downloaded update is empty.");
+
+            File.Move(partialPath, updatePath, true);
+            var completed = new AsyncCompletedEventArgs(null, false, null);
             if (GlobalConsts.UpdateLater)
-                await DownloadCompletedLater(this, new AsyncCompletedEventArgs(null, a.IsCanceled, null));
+                await DownloadCompletedLater(this, completed);
             else
-                await DownloadFileCompleted(this, new AsyncCompletedEventArgs(null, a.IsCanceled, null));
-        });
+                await DownloadFileCompleted(this, completed);
+        }
+        catch (OperationCanceledException)
+        {
+            try { if (File.Exists(partialPath)) File.Delete(partialPath); } catch { }
+            var cancelled = new AsyncCompletedEventArgs(null, true, null);
+            if (GlobalConsts.UpdateLater)
+                await DownloadCompletedLater(this, cancelled);
+            else
+                await DownloadFileCompleted(this, cancelled);
+        }
+        catch (Exception ex)
+        {
+            try { if (File.Exists(partialPath)) File.Delete(partialPath); } catch { }
+            var failed = new AsyncCompletedEventArgs(ex, false, null);
+            if (GlobalConsts.UpdateLater)
+                await DownloadCompletedLater(this, failed);
+            else
+                await DownloadFileCompleted(this, failed);
+        }
     }
 
     private async void DownloadProgressChanged(object sender, ProgressStreamReportEventArgs args)

--- a/YoutubePlaylistDownloader/DownloadUpdate.xaml.cs
+++ b/YoutubePlaylistDownloader/DownloadUpdate.xaml.cs
@@ -126,6 +126,10 @@ public partial class DownloadUpdate : UserControl, IDownload
 
             using var response = await httpClient.GetAsync(uri, HttpCompletionOption.ResponseHeadersRead, cancellationTokenSource.Token);
             response.EnsureSuccessStatusCode();
+            var finalUri = response.RequestMessage?.RequestUri;
+            if (finalUri is null || finalUri.Scheme != Uri.UriSchemeHttps ||
+                (finalUri.Host != "github.com" && finalUri.Host != "objects.githubusercontent.com"))
+                throw new InvalidDataException("The update URL redirected to an untrusted host.");
             await Dispatcher.InvokeAsync(() => CurrentDownloadProgressBar.Maximum = response.Content.Headers.ContentLength ?? 0);
 
             await using (var file = new ProgressStream(new FileStream(partialPath, FileMode.Create, FileAccess.Write, FileShare.None)))
@@ -134,8 +138,15 @@ public partial class DownloadUpdate : UserControl, IDownload
                 await response.Content.CopyToAsync(file, cancellationTokenSource.Token);
             }
 
-            if (!File.Exists(partialPath) || new FileInfo(partialPath).Length == 0)
+            if (!File.Exists(partialPath) || new FileInfo(partialPath).Length < 2)
                 throw new InvalidDataException("The downloaded update is empty.");
+
+            await using (var header = File.OpenRead(partialPath))
+            {
+                var signature = new byte[2];
+                if (await header.ReadAsync(signature, cancellationTokenSource.Token) != 2 || signature[0] != 'M' || signature[1] != 'Z')
+                    throw new InvalidDataException("The downloaded update is not a Windows executable.");
+            }
 
             File.Move(partialPath, updatePath, true);
             var completed = new AsyncCompletedEventArgs(null, false, null);
@@ -146,7 +157,7 @@ public partial class DownloadUpdate : UserControl, IDownload
         }
         catch (OperationCanceledException)
         {
-            try { if (File.Exists(partialPath)) File.Delete(partialPath); } catch { }
+            await CleanupPartialFile(partialPath);
             var cancelled = new AsyncCompletedEventArgs(null, true, null);
             if (GlobalConsts.UpdateLater)
                 await DownloadCompletedLater(this, cancelled);
@@ -155,12 +166,27 @@ public partial class DownloadUpdate : UserControl, IDownload
         }
         catch (Exception ex)
         {
-            try { if (File.Exists(partialPath)) File.Delete(partialPath); } catch { }
+            await CleanupPartialFile(partialPath);
             var failed = new AsyncCompletedEventArgs(ex, false, null);
             if (GlobalConsts.UpdateLater)
                 await DownloadCompletedLater(this, failed);
             else
                 await DownloadFileCompleted(this, failed);
+        }
+    }
+
+    private static async Task CleanupPartialFile(string partialPath)
+    {
+        if (!File.Exists(partialPath))
+            return;
+
+        try
+        {
+            File.Delete(partialPath);
+        }
+        catch (Exception ex)
+        {
+            await GlobalConsts.Log(ex.ToString(), "DownloadUpdate cleanup partial file");
         }
     }
 

--- a/YoutubePlaylistDownloader/GlobalConsts.cs
+++ b/YoutubePlaylistDownloader/GlobalConsts.cs
@@ -144,7 +144,7 @@ static class GlobalConsts
     {
         try
         {
-            File.WriteAllText(ConfigFilePath, JsonConvert.SerializeObject(settings));
+            AtomicFile.WriteAllText(ConfigFilePath, JsonConvert.SerializeObject(settings));
             SaveDownloadSettings();
         }
         catch (Exception ex)
@@ -571,7 +571,7 @@ static class GlobalConsts
     {
         try
         {
-            File.WriteAllText(DownloadSettingsFilePath, JsonConvert.SerializeObject(downloadSettings));
+            AtomicFile.WriteAllText(DownloadSettingsFilePath, JsonConvert.SerializeObject(downloadSettings));
         }
         catch (Exception ex)
         {
@@ -613,8 +613,12 @@ static class GlobalConsts
     {
         downloadSettings ??= DownloadSettings;
         downloadSettings.SchemaVersion = 1;
-        downloadSettings.SaveFormat = string.IsNullOrWhiteSpace(downloadSettings.SaveFormat) ? "mp3" : downloadSettings.SaveFormat.ToLowerInvariant();
-        downloadSettings.VideoSaveFormat = string.IsNullOrWhiteSpace(downloadSettings.VideoSaveFormat) ? "mkv" : downloadSettings.VideoSaveFormat.ToLowerInvariant();
+        downloadSettings.SaveFormat = downloadSettings.SaveFormat?.ToLowerInvariant();
+        if (!DownloadSettings.AudioFormats.Contains(downloadSettings.SaveFormat))
+            downloadSettings.SaveFormat = "mp3";
+        downloadSettings.VideoSaveFormat = downloadSettings.VideoSaveFormat?.ToLowerInvariant();
+        if (!DownloadSettings.VideoFormats.Contains(downloadSettings.VideoSaveFormat))
+            downloadSettings.VideoSaveFormat = "mkv";
         downloadSettings.Bitrate = string.IsNullOrWhiteSpace(downloadSettings.Bitrate) || !downloadSettings.Bitrate.All(char.IsDigit) ? "192" : downloadSettings.Bitrate;
         downloadSettings.CaptionsLanguage = string.IsNullOrWhiteSpace(downloadSettings.CaptionsLanguage) ? "en" : downloadSettings.CaptionsLanguage;
         downloadSettings.VideoLanguage = string.IsNullOrWhiteSpace(downloadSettings.VideoLanguage) ? "default" : downloadSettings.VideoLanguage;

--- a/YoutubePlaylistDownloader/GlobalConsts.cs
+++ b/YoutubePlaylistDownloader/GlobalConsts.cs
@@ -173,6 +173,7 @@ static class GlobalConsts
         try
         {
             settings = JsonConvert.DeserializeObject<Objects.Settings>(File.ReadAllText(ConfigFilePath));
+            NormalizeSettings();
             ConversionsLocker = new SemaphoreSlim(settings.ActualConversionsLimit, settings.MaximumConversionsCount);
 
             LoadDownloadSettings();
@@ -543,6 +544,7 @@ static class GlobalConsts
             try
             {
                 downloadSettings = JsonConvert.DeserializeObject<DownloadSettings>(File.ReadAllText(DownloadSettingsFilePath));
+                NormalizeDownloadSettings();
             }
             catch (Exception ex)
             {
@@ -575,6 +577,53 @@ static class GlobalConsts
         {
             Log(ex.ToString(), "SaveDownloadSettings at GlobalConsts").Wait();
         }
+    }
+
+    private static void NormalizeSettings()
+    {
+        settings ??= new Objects.Settings();
+        settings.SchemaVersion = 1;
+        settings.Theme = settings.Theme is "Light" or "Dark" ? settings.Theme : "Dark";
+        settings.Accent = string.IsNullOrWhiteSpace(settings.Accent) ? "Red" : settings.Accent;
+        settings.Language = string.IsNullOrWhiteSpace(settings.Language) ? "English" : settings.Language;
+        settings.SaveDirectory = GetValidSaveDirectory(settings.SaveDirectory);
+        settings.SubscriptionsDelay = settings.SubscriptionsDelay > TimeSpan.Zero
+            ? settings.SubscriptionsDelay
+            : TimeSpan.FromMinutes(1);
+        settings.MaximumConversionsCount = Math.Max(2, settings.MaximumConversionsCount);
+        settings.ActualConversionsLimit = Math.Clamp(settings.ActualConversionsLimit, 1, settings.MaximumConversionsCount - 1);
+    }
+
+    private static string GetValidSaveDirectory(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            return Environment.GetFolderPath(Environment.SpecialFolder.MyVideos);
+
+        try
+        {
+            return Path.GetFullPath(path);
+        }
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException)
+        {
+            return Environment.GetFolderPath(Environment.SpecialFolder.MyVideos);
+        }
+    }
+
+    private static void NormalizeDownloadSettings()
+    {
+        downloadSettings ??= DownloadSettings;
+        downloadSettings.SchemaVersion = 1;
+        downloadSettings.SaveFormat = string.IsNullOrWhiteSpace(downloadSettings.SaveFormat) ? "mp3" : downloadSettings.SaveFormat.ToLowerInvariant();
+        downloadSettings.VideoSaveFormat = string.IsNullOrWhiteSpace(downloadSettings.VideoSaveFormat) ? "mkv" : downloadSettings.VideoSaveFormat.ToLowerInvariant();
+        downloadSettings.Bitrate = string.IsNullOrWhiteSpace(downloadSettings.Bitrate) || !downloadSettings.Bitrate.All(char.IsDigit) ? "192" : downloadSettings.Bitrate;
+        downloadSettings.CaptionsLanguage = string.IsNullOrWhiteSpace(downloadSettings.CaptionsLanguage) ? "en" : downloadSettings.CaptionsLanguage;
+        downloadSettings.VideoLanguage = string.IsNullOrWhiteSpace(downloadSettings.VideoLanguage) ? "default" : downloadSettings.VideoLanguage;
+        downloadSettings.FilenamePattern = string.IsNullOrWhiteSpace(downloadSettings.FilenamePattern) ? "$title" : downloadSettings.FilenamePattern;
+        downloadSettings.SubsetStartIndex = Math.Max(0, downloadSettings.SubsetStartIndex);
+        downloadSettings.SubsetEndIndex = Math.Max(0, downloadSettings.SubsetEndIndex);
+        downloadSettings.FilterByLengthValue = double.IsFinite(downloadSettings.FilterByLengthValue) && downloadSettings.FilterByLengthValue > 0
+            ? downloadSettings.FilterByLengthValue
+            : 4;
     }
 
     private static void Downloads_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)

--- a/YoutubePlaylistDownloader/Languages/Português (BR).xaml
+++ b/YoutubePlaylistDownloader/Languages/Português (BR).xaml
@@ -136,7 +136,7 @@ rafaelpessoa21 (Português Brasileiro)
     <s:String x:Key="Video">Vídeo</s:String>
     <s:String x:Key="DownloadCaptions">Faça o download de legendas ocultas</s:String>
     <s:String x:Key="CaptionsLanguage">Idioma das legendas ocultas: </s:String>
-    <s:String x:Key="BulkDownload">Download em massa</s:String>
+    <s:String x:Key="BulkDownload">Download em lote</s:String>
     <s:String x:Key="LimitConverstions" >Limitar o máximo de conversões simultâneas para </s:String>
     <s:String x:Key="ValueChangeRequiresRestart">(Alterar este limite requer a reinicialização do programa para surtir efeito)</s:String>
     <s:String x:Key="ConversionsLimitingExplanation">Cada conversão de arquivo utiliza cerca de 1 núcleo (core) completo da CPU. Por exemplo: se você possui 4 núcleos de CPU, limitar o programa a 3 conversoes de arquivos ao mesmo tempo usará 3 núcleos de 4

--- a/YoutubePlaylistDownloader/MainPage.xaml.cs
+++ b/YoutubePlaylistDownloader/MainPage.xaml.cs
@@ -62,7 +62,7 @@ public partial class MainPage : UserControl
 
             if (YoutubeHelpers.TryParsePlaylistId(url, out var playlistId))
             {
-                var basePlaylist = await client.Playlists.GetAsync(playlistId.Value, token);
+                var basePlaylist = await client.Playlists.GetAsync(playlistId.Value, cancellationToken: token);
                 var videos = await client.Playlists.GetVideosAsync(basePlaylist.Id).CollectAsync(token);
                 token.ThrowIfCancellationRequested();
                 list = new FullPlaylist(basePlaylist, videos);
@@ -71,21 +71,21 @@ public partial class MainPage : UserControl
             }
             else if (YoutubeHelpers.TryParseChannelId(url, out var channelId))
             {
-                channel = await client.Channels.GetAsync(channelId, token);
+                channel = await client.Channels.GetAsync(channelId, cancellationToken: token);
                 list = new FullPlaylist(null, null, channel.Title);
                 VideoList = await client.Channels.GetUploadsAsync(channel.Id).CollectAsync(token);
                 await UpdatePlaylistInfo(Visibility.Visible, channel.Title, totalVideos: VideoList.Count().ToString(), imageUrl: channel.Thumbnails.FirstOrDefault()?.Url, downloadEnabled: true, showIndexes: true);
             }
             else if (YoutubeHelpers.TryParseUsername(url, out var username))
             {
-                var userChannel = await client.Channels.GetByUserAsync(username, token);
+                var userChannel = await client.Channels.GetByUserAsync(username, cancellationToken: token);
                 list = new FullPlaylist(null, null, userChannel.Title);
                 VideoList = await client.Channels.GetUploadsAsync(userChannel.Id).CollectAsync(token);
                 await UpdatePlaylistInfo(Visibility.Visible, userChannel.Title, totalVideos: VideoList.Count().ToString(), imageUrl: userChannel.Thumbnails.FirstOrDefault()?.Url, downloadEnabled: true, showIndexes: true);
             }
             else if (YoutubeHelpers.TryParseHandle(url, out var handle))
             {
-                var handleChannel = await client.Channels.GetByHandleAsync(handle, token);
+                var handleChannel = await client.Channels.GetByHandleAsync(handle, cancellationToken: token);
                 list = new FullPlaylist(null, null, handleChannel.Title);
                 VideoList = await client.Channels.GetUploadsAsync(handleChannel.Id).CollectAsync(token);
                 await UpdatePlaylistInfo(Visibility.Visible, handleChannel.Title, totalVideos: VideoList.Count().ToString(), imageUrl: handleChannel.Thumbnails.FirstOrDefault()?.Url, downloadEnabled: true, showIndexes: true);

--- a/YoutubePlaylistDownloader/MainPage.xaml.cs
+++ b/YoutubePlaylistDownloader/MainPage.xaml.cs
@@ -23,6 +23,7 @@ public partial class MainPage : UserControl
     private readonly string[] VideoFileTypes = ["mp4", "mkv"];
 
     private readonly string[] FileTypes = ["mp3", "aac", "opus", "wav", "flac", "m4a", "ogg", "webm"];
+    private CancellationTokenSource urlLookupCancellation;
 
     public MainPage()
     {
@@ -49,63 +50,60 @@ public partial class MainPage : UserControl
 
     private async void TextBox_TextChanged(object sender, TextChangedEventArgs e)
     {
+        urlLookupCancellation?.Cancel();
+        urlLookupCancellation?.Dispose();
+        urlLookupCancellation = new CancellationTokenSource();
+        var token = urlLookupCancellation.Token;
+        var url = PlaylistLinkTextBox.Text.Trim();
+
         try
         {
-            if (YoutubeHelpers.TryParsePlaylistId(PlaylistLinkTextBox.Text, out var playlistId))
-            {
-                _ = Task.Run(async () =>
-                {
-                    var basePlaylist = await client.Playlists.GetAsync(playlistId.Value).ConfigureAwait(false);
-                    list = new FullPlaylist(basePlaylist, await client.Playlists.GetVideosAsync(basePlaylist.Id).CollectAsync().ConfigureAwait(false));
-                    VideoList = new List<PlaylistVideo>();
-                    await UpdatePlaylistInfo(Visibility.Visible, list.BasePlaylist.Title, list.BasePlaylist.Author?.ChannelTitle ?? "", "", list.Videos.Count().ToString(), $"https://img.youtube.com/vi/{list?.Videos?.FirstOrDefault()?.Id}/maxresdefault.jpg", true, true);
-                }).ConfigureAwait(false);
-            }
-            else if (YoutubeHelpers.TryParseChannelId(PlaylistLinkTextBox.Text, out var channelId))
-            {
-                _ = Task.Run(async () =>
-                {
-                    channel = await client.Channels.GetAsync(channelId).ConfigureAwait(false);
-                    list = new FullPlaylist(null, null, channel.Title);
-                    VideoList = await client.Channels.GetUploadsAsync(channel.Id).CollectAsync().ConfigureAwait(false);
-                    await UpdatePlaylistInfo(Visibility.Visible, channel.Title, totalVideos: VideoList.Count().ToString(), imageUrl: channel.Thumbnails.FirstOrDefault()?.Url, downloadEnabled: true, showIndexes: true);
-                }).ConfigureAwait(false);
-            }
-            else if (YoutubeHelpers.TryParseUsername(PlaylistLinkTextBox.Text, out var username))
-            {
-                _ = Task.Run(async () =>
-                {
-                    var channel = await client.Channels.GetByUserAsync(username).ConfigureAwait(false);
-                    list = new FullPlaylist(null, null, channel.Title);
-                    VideoList = await client.Channels.GetUploadsAsync(channel.Id).CollectAsync().ConfigureAwait(false);
-                    await UpdatePlaylistInfo(Visibility.Visible, channel.Title, totalVideos: VideoList.Count().ToString(), imageUrl: channel.Thumbnails.FirstOrDefault()?.Url, downloadEnabled: true, showIndexes: true);
-                }).ConfigureAwait(false);
-            }
-            else if (YoutubeHelpers.TryParseHandle(PlaylistLinkTextBox.Text, out var handle))
-            {
-                _ = Task.Run(async () =>
-                {
-                    var channel = await client.Channels.GetByHandleAsync(handle).ConfigureAwait(false);
-                    list = new FullPlaylist(null, null, channel.Title);
-                    VideoList = await client.Channels.GetUploadsAsync(channel.Id).CollectAsync().ConfigureAwait(false);
-                    await UpdatePlaylistInfo(Visibility.Visible, channel.Title, totalVideos: VideoList.Count().ToString(), imageUrl: channel.Thumbnails.FirstOrDefault()?.Url, downloadEnabled: true, showIndexes: true);
-                }).ConfigureAwait(false);
-            }
-            else if (YoutubeHelpers.TryParseVideoId(PlaylistLinkTextBox.Text, out var videoId))
-            {
-                _ = Task.Run(async () =>
-                {
-                    var video = await client.Videos.GetAsync(videoId);
-                    VideoList = new List<Video> { video };
-                    list = new FullPlaylist(null, null);
-                    await UpdatePlaylistInfo(Visibility.Visible, video.Title, video.Author.ChannelTitle, video.Engagement.ViewCount.ToString(), string.Empty, $"https://img.youtube.com/vi/{video.Id}/maxresdefault.jpg", true, false);
+            await Task.Delay(300, token);
 
-                }).ConfigureAwait(false);
+            if (YoutubeHelpers.TryParsePlaylistId(url, out var playlistId))
+            {
+                var basePlaylist = await client.Playlists.GetAsync(playlistId.Value, token);
+                var videos = await client.Playlists.GetVideosAsync(basePlaylist.Id).CollectAsync(token);
+                token.ThrowIfCancellationRequested();
+                list = new FullPlaylist(basePlaylist, videos);
+                VideoList = new List<PlaylistVideo>();
+                await UpdatePlaylistInfo(Visibility.Visible, list.BasePlaylist.Title, list.BasePlaylist.Author?.ChannelTitle ?? "", "", list.Videos.Count().ToString(), $"https://img.youtube.com/vi/{list?.Videos?.FirstOrDefault()?.Id}/maxresdefault.jpg", true, true);
+            }
+            else if (YoutubeHelpers.TryParseChannelId(url, out var channelId))
+            {
+                channel = await client.Channels.GetAsync(channelId, token);
+                list = new FullPlaylist(null, null, channel.Title);
+                VideoList = await client.Channels.GetUploadsAsync(channel.Id).CollectAsync(token);
+                await UpdatePlaylistInfo(Visibility.Visible, channel.Title, totalVideos: VideoList.Count().ToString(), imageUrl: channel.Thumbnails.FirstOrDefault()?.Url, downloadEnabled: true, showIndexes: true);
+            }
+            else if (YoutubeHelpers.TryParseUsername(url, out var username))
+            {
+                var userChannel = await client.Channels.GetByUserAsync(username, token);
+                list = new FullPlaylist(null, null, userChannel.Title);
+                VideoList = await client.Channels.GetUploadsAsync(userChannel.Id).CollectAsync(token);
+                await UpdatePlaylistInfo(Visibility.Visible, userChannel.Title, totalVideos: VideoList.Count().ToString(), imageUrl: userChannel.Thumbnails.FirstOrDefault()?.Url, downloadEnabled: true, showIndexes: true);
+            }
+            else if (YoutubeHelpers.TryParseHandle(url, out var handle))
+            {
+                var handleChannel = await client.Channels.GetByHandleAsync(handle, token);
+                list = new FullPlaylist(null, null, handleChannel.Title);
+                VideoList = await client.Channels.GetUploadsAsync(handleChannel.Id).CollectAsync(token);
+                await UpdatePlaylistInfo(Visibility.Visible, handleChannel.Title, totalVideos: VideoList.Count().ToString(), imageUrl: handleChannel.Thumbnails.FirstOrDefault()?.Url, downloadEnabled: true, showIndexes: true);
+            }
+            else if (YoutubeHelpers.TryParseVideoId(url, out var videoId))
+            {
+                var video = await client.Videos.GetAsync(videoId, token);
+                VideoList = new List<Video> { video };
+                list = new FullPlaylist(null, null);
+                await UpdatePlaylistInfo(Visibility.Visible, video.Title, video.Author.ChannelTitle, video.Engagement.ViewCount.ToString(), string.Empty, $"https://img.youtube.com/vi/{video.Id}/maxresdefault.jpg", true, false);
             }
             else
             {
                 await UpdatePlaylistInfo().ConfigureAwait(false);
             }
+        }
+        catch (OperationCanceledException) when (token.IsCancellationRequested)
+        {
         }
 
         catch (Exception ex)

--- a/YoutubePlaylistDownloader/MainPage.xaml.cs
+++ b/YoutubePlaylistDownloader/MainPage.xaml.cs
@@ -48,6 +48,14 @@ public partial class MainPage : UserControl
         return this;
     }
 
+    private static async Task<List<T>> CollectAsync<T>(IAsyncEnumerable<T> source, CancellationToken cancellationToken)
+    {
+        var result = new List<T>();
+        await foreach (var item in source.WithCancellation(cancellationToken))
+            result.Add(item);
+        return result;
+    }
+
     private async void TextBox_TextChanged(object sender, TextChangedEventArgs e)
     {
         urlLookupCancellation?.Cancel();
@@ -63,7 +71,7 @@ public partial class MainPage : UserControl
             if (YoutubeHelpers.TryParsePlaylistId(url, out var playlistId))
             {
                 var basePlaylist = await client.Playlists.GetAsync(playlistId.Value, cancellationToken: token);
-                var videos = await client.Playlists.GetVideosAsync(basePlaylist.Id).CollectAsync(token);
+                var videos = await CollectAsync(client.Playlists.GetVideosAsync(basePlaylist.Id), token);
                 token.ThrowIfCancellationRequested();
                 list = new FullPlaylist(basePlaylist, videos);
                 VideoList = new List<PlaylistVideo>();
@@ -73,21 +81,21 @@ public partial class MainPage : UserControl
             {
                 channel = await client.Channels.GetAsync(channelId, cancellationToken: token);
                 list = new FullPlaylist(null, null, channel.Title);
-                VideoList = await client.Channels.GetUploadsAsync(channel.Id).CollectAsync(token);
+                VideoList = await CollectAsync(client.Channels.GetUploadsAsync(channel.Id), token);
                 await UpdatePlaylistInfo(Visibility.Visible, channel.Title, totalVideos: VideoList.Count().ToString(), imageUrl: channel.Thumbnails.FirstOrDefault()?.Url, downloadEnabled: true, showIndexes: true);
             }
             else if (YoutubeHelpers.TryParseUsername(url, out var username))
             {
                 var userChannel = await client.Channels.GetByUserAsync(username, cancellationToken: token);
                 list = new FullPlaylist(null, null, userChannel.Title);
-                VideoList = await client.Channels.GetUploadsAsync(userChannel.Id).CollectAsync(token);
+                VideoList = await CollectAsync(client.Channels.GetUploadsAsync(userChannel.Id), token);
                 await UpdatePlaylistInfo(Visibility.Visible, userChannel.Title, totalVideos: VideoList.Count().ToString(), imageUrl: userChannel.Thumbnails.FirstOrDefault()?.Url, downloadEnabled: true, showIndexes: true);
             }
             else if (YoutubeHelpers.TryParseHandle(url, out var handle))
             {
                 var handleChannel = await client.Channels.GetByHandleAsync(handle, cancellationToken: token);
                 list = new FullPlaylist(null, null, handleChannel.Title);
-                VideoList = await client.Channels.GetUploadsAsync(handleChannel.Id).CollectAsync(token);
+                VideoList = await CollectAsync(client.Channels.GetUploadsAsync(handleChannel.Id), token);
                 await UpdatePlaylistInfo(Visibility.Visible, handleChannel.Title, totalVideos: VideoList.Count().ToString(), imageUrl: handleChannel.Thumbnails.FirstOrDefault()?.Url, downloadEnabled: true, showIndexes: true);
             }
             else if (YoutubeHelpers.TryParseVideoId(url, out var videoId))

--- a/YoutubePlaylistDownloader/Objects/DownloadSettings.cs
+++ b/YoutubePlaylistDownloader/Objects/DownloadSettings.cs
@@ -3,6 +3,8 @@
 [JsonObject]
 public class DownloadSettings
 {
+    public static readonly string[] AudioFormats = ["mp3", "aac", "opus", "wav", "flac", "m4a", "ogg", "webm"];
+    public static readonly string[] VideoFormats = ["mp4", "mkv"];
     [JsonProperty]
     public int SchemaVersion { get; set; } = 1;
     [JsonProperty]

--- a/YoutubePlaylistDownloader/Objects/DownloadSettings.cs
+++ b/YoutubePlaylistDownloader/Objects/DownloadSettings.cs
@@ -4,6 +4,8 @@
 public class DownloadSettings
 {
     [JsonProperty]
+    public int SchemaVersion { get; set; } = 1;
+    [JsonProperty]
     public string SavePath { get; set; }
 
     [JsonProperty(DefaultValueHandling = DefaultValueHandling.Populate)]

--- a/YoutubePlaylistDownloader/Objects/Settings.cs
+++ b/YoutubePlaylistDownloader/Objects/Settings.cs
@@ -4,6 +4,8 @@
 public class Settings
 {
     [JsonProperty]
+    public int SchemaVersion { get; set; } = 1;
+    [JsonProperty]
     public string Theme { get; set; }
 
     [JsonProperty]

--- a/YoutubePlaylistDownloader/Utilities/AtomicFile.cs
+++ b/YoutubePlaylistDownloader/Utilities/AtomicFile.cs
@@ -2,6 +2,22 @@ namespace YoutubePlaylistDownloader.Utilities;
 
 public static class AtomicFile
 {
+    public static void WriteAllText(string destinationPath, string contents)
+    {
+        var partialPath = destinationPath + ".part";
+        try
+        {
+            File.WriteAllText(partialPath, contents);
+            File.Move(partialPath, destinationPath, true);
+        }
+        catch
+        {
+            if (File.Exists(partialPath))
+                File.Delete(partialPath);
+            throw;
+        }
+    }
+
     public static void CopyAndReplace(string sourcePath, string destinationPath)
     {
         var partialPath = destinationPath + ".part";

--- a/YoutubePlaylistDownloader/Utilities/AtomicFile.cs
+++ b/YoutubePlaylistDownloader/Utilities/AtomicFile.cs
@@ -1,0 +1,20 @@
+namespace YoutubePlaylistDownloader.Utilities;
+
+public static class AtomicFile
+{
+    public static void CopyAndReplace(string sourcePath, string destinationPath)
+    {
+        var partialPath = destinationPath + ".part";
+        try
+        {
+            File.Copy(sourcePath, partialPath, true);
+            File.Move(partialPath, destinationPath, true);
+        }
+        catch
+        {
+            if (File.Exists(partialPath))
+                File.Delete(partialPath);
+            throw;
+        }
+    }
+}

--- a/YoutubePlaylistDownloader/Utilities/DownloadPaths.cs
+++ b/YoutubePlaylistDownloader/Utilities/DownloadPaths.cs
@@ -1,0 +1,15 @@
+namespace YoutubePlaylistDownloader.Utilities;
+
+public sealed record DownloadPaths(string Input, string Output, string Destination, string Audio, string Captions)
+{
+    public static DownloadPaths Create(string tempFolder, string baseName, string extension, string audioExtension = null)
+    {
+        var input = $"{tempFolder}{baseName}.part";
+        var output = $"{tempFolder}{baseName}.part.{extension}";
+        var audio = audioExtension == null ? string.Empty : $"{tempFolder}{baseName}-audio.{audioExtension}.part";
+        var captions = $"{tempFolder}{baseName}.srt.part";
+        return new(input, output, string.Empty, audio, captions);
+    }
+
+    public DownloadPaths WithDestination(string destination) => this with { Destination = destination };
+}

--- a/docs/upstream-pr-summary.md
+++ b/docs/upstream-pr-summary.md
@@ -1,0 +1,133 @@
+# Upstream contribution: download pipeline hardening
+
+Target repository: `shaked6540/YoutubePlaylistDownloader`
+
+This document is a draft for an upstream pull request. It summarizes the
+changes already reviewed and merged in the fork through PR #15. The cancelled
+UI/UX redesign is intentionally not included.
+
+## Proposed pull request summary
+
+This contribution hardens the download pipeline without changing the existing
+user-facing workflow. It makes URL lookups and FFmpeg conversion cancellable,
+prevents incomplete files from replacing valid files, validates persisted
+settings, reduces progress-update overhead, adds Windows CI coverage, and
+removes duplicated path-building logic.
+
+## Changes included
+
+### URL lookup and FFmpeg lifecycle
+
+- Debounce URL input by 300 ms.
+- Cancel superseded YouTube lookups and ignore stale responses.
+- Pass named cancellation tokens through YoutubeExplode calls.
+- Await FFmpeg conversion tasks instead of using fire-and-forget work.
+- Validate FFmpeg exit status and output existence before promoting a result.
+- Terminate FFmpeg cleanly when cancellation occurs.
+- Release conversion slots reliably after success, failure, or cancellation.
+
+Source fork PR: #11 (`9fbdf08`)
+
+### CI and updater safety
+
+- Add GitHub Actions restore/build validation on Windows with .NET 8.
+- Restrict workflow permissions to read-only repository contents.
+- Download updates to a `.part` file first.
+- Accept only HTTPS URLs from the official GitHub hosts.
+- Validate HTTP status and reject empty/non-Windows update files.
+- Promote the installer only after the complete download succeeds.
+- Remove partial files after failures and cancellation.
+- Replace the asynchronous `ContinueWith` chain with an awaitable flow.
+- Document local build/run requirements and FFmpeg placement in `README.md`.
+
+Source fork PR: #12 (`32374e9`)
+
+### Atomic download and conversion outputs
+
+- Stage video, converted audio, captions, and subtitle files as `.part` files.
+- Promote completed files atomically.
+- Preserve an existing valid destination when a new operation fails.
+- Clean temporary files in `finally` blocks.
+- Add xUnit coverage for successful promotion and failure preservation.
+
+Source fork PR: #13 (`45fd376`)
+
+### Settings validation and progress updates
+
+- Normalize persisted settings and add schema-version fields.
+- Validate formats, bitrate, playlist indexes, conversion limits, paths, and
+  other persisted values.
+- Fall back to safe defaults when stored values are invalid.
+- Save settings through atomic replacement.
+- Throttle intermediate progress dispatcher updates to 100 ms.
+- Preserve the final 100% progress update.
+- Add coverage for atomic settings-file replacement.
+
+Source fork PR: #14 (`d43e2ae`)
+
+### Shared download path model
+
+- Centralize input, temporary, output, audio, caption, and destination path
+  construction in `Utilities/DownloadPaths.cs`.
+- Reuse the same path model in both download flows.
+- Add characterization tests for generated temporary and final paths.
+- Preserve existing download behavior while removing duplicated path logic.
+
+Source fork PR: #15 (`912501d`)
+
+## Compatibility and scope
+
+- The application remains a Windows WPF application targeting .NET 8.
+- FFmpeg is still required for video conversion and merged media output.
+- Existing download settings, formats, translations, and UI behavior are kept.
+- No UI redesign, theme change, or new runtime dependency is included.
+- Authenticode signature verification is not included; it requires an official
+  publisher certificate and a signing pipeline owned by the project.
+
+## Validation
+
+Run on Windows with the .NET 8 SDK and the Desktop development with .NET
+workload installed:
+
+```powershell
+dotnet restore YoutubePlaylistDownloader.sln
+dotnet build YoutubePlaylistDownloader.sln --configuration Debug
+dotnet test YoutubePlaylistDownloader.sln --configuration Debug
+```
+
+For manual validation, place `ffmpeg.exe` beside the generated executable and
+verify these flows:
+
+1. Replace a URL while a lookup is still running; only the latest URL may
+   update the page.
+2. Cancel or interrupt a conversion; no partial output may replace an
+   existing file.
+3. Restart with invalid persisted settings; safe defaults must be loaded.
+4. Download a playlist and confirm that the final progress reaches 100%.
+5. Trigger an update download failure and confirm that the existing installer
+   remains intact and `.part` files are removed.
+
+## Suggested upstream submission flow
+
+```powershell
+git remote add upstream https://github.com/shaked6540/YoutubePlaylistDownloader.git
+git fetch upstream
+git switch -c upstream/download-pipeline-hardening upstream/master
+
+# Apply the reviewed commits in dependency order.
+git cherry-pick 10f134dbe60ded0d89724002fce10aef5aa21750
+git cherry-pick 90fa5507f9316b69dc0cd594eacec4bcd1efecb0
+git cherry-pick 4839e9c6c5e5d6dc97a162cf84ad709b0bf7bccf
+git cherry-pick 6ab9b03f6616de52c5da4cc1e10b623f5f4f23a0
+git cherry-pick e0524463114c702797c017c9a6278d312744f56d
+git cherry-pick f13b27e53915b824ec23184e04166a446557c560
+git cherry-pick 0b4af7b64ac5a0f0bbe84932daf5cf6b47ef7861
+```
+
+If the upstream branch has diverged, resolve conflicts one commit at a time,
+run the validation commands above, push the branch to the fork, and open the
+pull request against `shaked6540/YoutubePlaylistDownloader:master`.
+
+## Suggested pull request title
+
+`Harden download pipeline and add Windows CI coverage`


### PR DESCRIPTION
## Summary

This PR ports the reviewed download-pipeline improvements from the fork into the upstream repository. The changes preserve the existing WPF workflow while making lookups, conversions, file promotion, settings handling, and updater behavior safer and more predictable.

## What changed

- Debounce URL input and cancel superseded YouTube lookups so stale responses cannot overwrite the current result.
- Thread cancellation tokens through YoutubeExplode calls.
- Await FFmpeg conversions, validate exit codes and output files, and terminate cancelled processes cleanly.
- Add Windows/.NET 8 GitHub Actions validation with read-only workflow permissions.
- Harden update downloads with HTTPS/official GitHub host validation, HTTP checks, non-empty file validation, `.part` staging, and cleanup on failure.
- Promote downloaded, converted, audio, caption, and subtitle files atomically while preserving existing valid destinations on failure.
- Add xUnit coverage for atomic file promotion, settings replacement, and generated download paths.
- Normalize and validate persisted settings with schema versions and safe fallbacks for invalid values.
- Atomically save settings files.
- Throttle intermediate progress dispatcher updates to 100 ms while preserving the final 100% update.
- Centralize temporary, output, audio, caption, and destination path construction in a shared download-path model used by both download flows.
- Document local .NET 8, WPF, and FFmpeg build requirements.

## Compatibility and scope

- The application remains a Windows WPF application targeting .NET 8.
- Existing download settings, formats, translations, and UI behavior are preserved.
- No UI redesign or new runtime dependency is introduced.
- FFmpeg remains required for video conversion and merged media output.
- Authenticode signature verification is outside this PR because it requires an official publisher certificate and signing pipeline.

## Validation

The solution and test project are covered by the Windows CI workflow. The expected local commands are:

```powershell
dotnet restore YoutubePlaylistDownloader.sln
dotnet build YoutubePlaylistDownloader.sln --configuration Debug
dotnet test YoutubePlaylistDownloader.sln --configuration Debug
```

Manual validation should cover cancelled/stale URL lookups, interrupted FFmpeg conversions, invalid persisted settings, final progress reaching 100%, and failed updater downloads leaving the existing installer intact.

## Source history

These changes were developed and reviewed in the fork through PRs #11–#15. The fork-side implementation is based on commits `10f134d`, `90fa550`, `4839e9c`, `6ab9b03`, `e052446`, `f13b27e`, and `0b4af7b`.
